### PR TITLE
Occu pen

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Collate: 'classes.R' 'unmarkedEstimate.R' 'mapInfo.R' 'unmarkedFrame.R'
     'unmarkedFit.R' 'utils.R' 'getDesign.R' 'colext.R' 'distsamp.R'
     'multinomPois.R' 'occu.R' 'occuRN.R' 'pcount.R' 'gmultmix.R'
     'pcountOpen.R' 'gdistsamp.R' 'unmarkedFitList.R' 'unmarkedLinComb.R'
-    'ranef.R' 'boot.R' 'occuFP.R' 'gpcount.R'
+    'ranef.R' 'boot.R' 'occuFP.R' 'gpcount.R' 'occuPEN.R'
 LinkingTo: Rcpp, RcppArmadillo (>= 0.2.0)
 SystemRequirements: GNU make
 URL: http://groups.google.com/group/unmarked,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -9,7 +9,7 @@ import(lattice, methods, Rcpp)
 
 # Fitting functions
 export(occu, occuFP, occuRN, pcount, pcountOpen, multinomPois, distsamp,
-       colext, gmultmix, gdistsamp, gpcount)
+       colext, gmultmix, gdistsamp, gpcount, occuPEN, occuPEN_CV, computeMPLElambda)
 export(removalPiFun, doublePiFun)
 
 # S4 classes

--- a/R/occuPEN.R
+++ b/R/occuPEN.R
@@ -1,0 +1,320 @@
+
+#  Fit the penalized occupancy models of Hutchinson et al (2015).
+
+computeMPLElambda = function(formula, data, knownOcc = numeric(0), starts, method = "BFGS", engine = c("C", "R")) {
+
+  designMats <- getDesign(data, formula)
+  X <- designMats$X; V <- designMats$V; y <- designMats$y
+  removed <- designMats$removed.sites
+  y <- truncateToBinary(y)
+
+  ## convert knownOcc to logical so we can correctly to handle NAs.
+  knownOccLog <- rep(FALSE, numSites(data))
+  knownOccLog[knownOcc] <- TRUE
+  if(length(removed)>0)
+     knownOccLog <- knownOccLog[-removed]
+
+  nDP <- ncol(V)
+  nOP <- ncol(X)
+  nP <- nDP + nOP
+  if(!missing(starts) && length(starts) != nP)
+      stop(paste("The number of starting values should be", nP))
+  if(missing(starts)) starts <- rep(0, nP)
+
+  LRparams = glm.fit(x=X,y=apply(y,1,max),family=binomial(),intercept=F,start=starts[1:nOP])
+  naiveOcc = mean(LRparams$fitted.values)
+  occuOutMLE = occu(formula,data,knownOcc, starts,
+                 method = "BFGS", engine = c("C", "R"), se = TRUE)
+  meanDet = mean((1+exp(-occuOutMLE[2]@estimates%*%t(V)))^-1)
+  MPLElambda = sqrt(sum(diag(occuOutMLE[2]@covMat)))*(1-(1-meanDet)^(dim(y)[2]))*(1-naiveOcc) # what if there are different numbers of visits to different sites?
+  return(MPLElambda)      
+}
+
+occuPEN_CV <- function(formula, data, knownOcc = numeric(0), starts,
+                 method = "BFGS", engine = c("C", "R"), 
+		 lambdaVec = c(0,2^seq(-4,4)),
+		 pen.type = c("Bayes","Ridge"),
+		 k = 5,
+		 foldAssignments = NA,
+		 ...) 
+{
+  if(!is(data, "unmarkedFrameOccu"))
+        stop("Data is not an unmarkedFrameOccu object.")
+
+  pen.type = pen.type[1]
+  if (pen.type=="MPLE") stop("MPLE does not require cross-validation.")
+  if (!(pen.type=="Bayes" | pen.type=="Ridge")) 
+      stop("pen.type not recognized.  Choose Bayes or Ridge.")
+
+  if (length(lambdaVec)==1) stop("Must provide more than one lambda for cross-validation.")
+  
+  engine <- match.arg(engine, c("C", "R"))
+  designMats <- getDesign(data, formula)
+  X <- designMats$X; V <- designMats$V; y <- designMats$y
+  y <- truncateToBinary(y)
+  J <- ncol(y)
+  M <- nrow(y)
+  
+  if (!(length(foldAssignments)==1 & is.na(foldAssignments)[1])) { # user-supplied foldAssignments
+    if (!(k==length(unique(foldAssignments)))) stop("Value of k does not match number of folds indicated in foldAssignments.")
+  } else { # create foldAssignments 
+  # attempt to include sites with and without observations in each fold
+    foldAssignments = c(1:M)
+    idxsWithObs = which(rowSums(y)>0)
+    idxsWoObs = which(rowSums(y)==0)
+    if (length(idxsWithObs)>0 & length(idxsWoObs)>0) {
+      foldAssignments[idxsWithObs] = sample(rep(1:k,ceiling(length(idxsWithObs)/k))[1:length(idxsWithObs)])
+      foldAssignments[idxsWoObs] = sample(rep(1:k,ceiling(length(idxsWoObs)/k))[1:length(idxsWoObs)])
+    } else if (k<=M) {
+      foldAssignments = sample(rep(1:k,ceiling(M/k)))[1:M]
+    } else {
+      stop("k>M. More folds than sites creates folds. Specify a smaller k.")
+    }     
+  }
+  #print(foldAssignments)
+  foldNames = unique(foldAssignments)
+
+  if(identical(engine, "C")) {
+    nll <- function(params) {
+          beta.psi <- params[1:nOP]
+          beta.p <- params[(nOP+1):nP]
+          .Call("nll_occu",
+                  yvec, X, V, beta.psi, beta.p, nd, knownOccLog, navec,
+                  X.offset, V.offset, 
+                  PACKAGE = "unmarked")
+      }
+  } else {
+    nll <- function(params) { # penalize this function
+        psi <- plogis(X %*% params[1 : nOP] + X.offset)
+        psi[knownOccLog] <- 1
+        pvec <- plogis(V %*% params[(nOP + 1) : nP] + V.offset)
+        cp <- (pvec^yvec) * ((1 - pvec)^(1 - yvec))
+        cp[navec] <- 1 # so that NA's don't modify likelihood
+        cpmat <- matrix(cp, M, J, byrow = TRUE) #
+        loglik <- log(rowProds(cpmat) * psi + nd * (1 - psi))
+        -sum(loglik)
+    }
+  } # end if (engine)
+ 
+  lambdaScores = lambdaVec*0 # score by held-out likelihood
+
+  for (f in 1:k) {				  
+    fold = foldNames[f]
+    occuTrain = data[which(foldAssignments!=fold),] # train on NOT this fold
+    occuTest = data[which(foldAssignments==fold),] # test on this fold
+    
+    designMats <- getDesign(occuTest, formula)
+    X <- designMats$X; V <- designMats$V; y <- designMats$y
+    removed <- designMats$removed.sites
+    X.offset <- designMats$X.offset; V.offset <- designMats$V.offset
+    if(is.null(X.offset)) {
+        X.offset <- rep(0, nrow(X))
+    }
+    if(is.null(V.offset)) {
+        V.offset <- rep(0, nrow(V))
+    }
+
+    y <- truncateToBinary(y)
+    J <- ncol(y)
+    M <- nrow(y)
+
+    ## convert knownOcc to logical so we can correctly to handle NAs.
+    knownOccLog <- rep(FALSE, numSites(data))
+    knownOccLog[knownOcc] <- TRUE
+    if(length(removed)>0)
+        knownOccLog <- knownOccLog[-removed]
+
+    occParms <- colnames(X)
+    detParms <- colnames(V)
+    nDP <- ncol(V)
+    nOP <- ncol(X)
+    nP <- nDP + nOP
+
+    if(!missing(starts) && length(starts) != nP)
+        stop(paste("The number of starting values should be", nP))
+    if(missing(starts)) starts <- rep(0, nP)
+
+    yvec <- as.numeric(t(y))
+    navec <- is.na(yvec)
+    nd <- ifelse(rowSums(y,na.rm=TRUE) == 0, 1, 0) # no det at site i
+
+    # For each lambda, get parameters on the training set, and use them
+    #  to compute the likelihood on the held-out test fold.
+    for (la in 1:length(lambdaVec)) { 
+      occuOut = occuPEN(formula, occuTrain, starts, lambda=lambdaVec[la],pen.type=pen.type) 
+      ests = c(as.numeric(occuOut[1]@estimates),as.numeric(occuOut[2]@estimates))
+      lambdaScores[la] = lambdaScores[la] + nll(ests)
+    } # la
+  } # f
+
+  bestLambda = lambdaVec[which.min(lambdaScores)]
+  #print(lambdaScores)
+
+  occuOut = occuPEN(formula, data, starts=starts, lambda=bestLambda, pen.type=pen.type) 
+ 
+  umfit <- new("unmarkedFitOccuPEN_CV", fitType = "occu", call = match.call(),
+                 formula = formula, data = data,
+                 sitesRemoved = designMats$removed.sites,
+                 estimates = occuOut@estimates, AIC = occuOut@AIC, 
+		 opt = occuOut@opt,
+                 negLogLike = occuOut@negLogLike,
+                 nllFun = occuOut@nllFun, knownOcc = knownOccLog, 
+		 pen.type = pen.type, lambdaVec = lambdaVec,
+		 k = k, foldAssignments = foldAssignments,
+		 lambdaScores = lambdaScores, chosenLambda = bestLambda)
+
+  return(umfit)
+
+} # fn: occuPEN_CV
+
+occuPEN <- function(formula, data, knownOcc = numeric(0), starts,
+                 method = "BFGS", engine = c("C", "R"),
+#		 se = TRUE, 
+		 lambda = 0, 
+		 pen.type = c("Bayes","Ridge","MPLE"),
+		 ...) 
+ {
+    if(!is(data, "unmarkedFrameOccu"))
+        stop("Data is not an unmarkedFrameOccu object.")
+
+    pen.type = pen.type[1]
+    if (!(pen.type=="Bayes" | pen.type=="Ridge" | pen.type=="MPLE")) 
+        stop("pen.type not recognized.  Choose Bayes, Ridge, or MPLE.")
+
+    engine <- match.arg(engine, c("C", "R"))
+
+    designMats <- getDesign(data, formula)
+    X <- designMats$X; V <- designMats$V; y <- designMats$y
+
+    if (ncol(X)==1 & pen.type=="MPLE") stop("MPLE requires occupancy covariates.")
+
+    if (ncol(X)==1 & ncol(V)==1 & pen.type=="Ridge") stop("Ridge requires covariates.")
+
+    removed <- designMats$removed.sites
+    X.offset <- designMats$X.offset; V.offset <- designMats$V.offset
+    if(is.null(X.offset)) {
+        X.offset <- rep(0, nrow(X))
+    }
+    if(is.null(V.offset)) {
+        V.offset <- rep(0, nrow(V))
+    }
+
+    y <- truncateToBinary(y)
+    J <- ncol(y)
+    M <- nrow(y)
+
+    ## convert knownOcc to logical so we can correctly to handle NAs.
+    knownOccLog <- rep(FALSE, numSites(data))
+    knownOccLog[knownOcc] <- TRUE
+    if(length(removed)>0)
+        knownOccLog <- knownOccLog[-removed]
+
+    occParms <- colnames(X)
+    detParms <- colnames(V)
+    nDP <- ncol(V)
+    nOP <- ncol(X)
+
+    nP <- nDP + nOP
+    if(!missing(starts) && length(starts) != nP)
+        stop(paste("The number of starting values should be", nP))
+    if(missing(starts)) starts <- rep(0, nP)
+
+    yvec <- as.numeric(t(y))
+    navec <- is.na(yvec)
+    nd <- ifelse(rowSums(y,na.rm=TRUE) == 0, 1, 0) # no det at site i
+
+    ## need to add offsets !!!!!!!!!!!!!!
+    ## and fix bug causing crash when NAs are in V
+
+    ## compute logistic regression MPLE targets and lambda:
+    if (pen.type=="MPLE") {
+      LRparams = glm.fit(x=X,y=apply(y,1,max),family=binomial(),intercept=F,start=starts[1:nOP])
+      MPLElambda = computeMPLElambda(formula, data, knownOcc = numeric(0), starts, method = "BFGS", engine = c("C", "R"))
+      if (MPLElambda != lambda) warning("Supplied lambda does not match the computed value. Proceeding with the supplied lambda.")
+    }
+    
+    if(identical(engine, "C")) {
+        nll <- function(params) {
+            beta.psi <- params[1:nOP]
+            beta.p <- params[(nOP+1):nP]
+  	    if (pen.type=="Bayes") {
+	      penalty = sum(params^2)*lambda*0.5
+  	    } else if (pen.type=="Ridge") {
+	      penalty = 0
+	      if (nOP>1) { penalty = penalty + sum((params[2:nOP])^2) }
+	      if (nDP>1) { penalty = penalty + sum((params[(nOP+2):nP])^2) }
+	      penalty = penalty*lambda*0.5
+	    } else if (pen.type=="MPLE") {
+	      penalty = abs(params[1:nOP]-LRparams$coefficients)
+	      penalty = sum(penalty)*lambda
+	    } else {
+	      stop("pen.type not found")
+	    }
+	
+            .Call("nll_occuPEN",
+                  yvec, X, V, beta.psi, beta.p, nd, knownOccLog, navec,
+                  X.offset, V.offset, penalty,
+                  PACKAGE = "unmarked")
+        }
+    } else {
+      nll <- function(params) { # penalize this function
+          psi <- plogis(X %*% params[1 : nOP] + X.offset)
+          psi[knownOccLog] <- 1
+          pvec <- plogis(V %*% params[(nOP + 1) : nP] + V.offset)
+          cp <- (pvec^yvec) * ((1 - pvec)^(1 - yvec))
+          cp[navec] <- 1 # so that NA's don't modify likelihood
+          cpmat <- matrix(cp, M, J, byrow = TRUE) #
+          loglik <- log(rowProds(cpmat) * psi + nd * (1 - psi))
+          #-sum(loglik)
+ 
+  	  if (pen.type=="Bayes") {
+	    penalty = sum(params^2)*lambda*0.5
+  	  } else if (pen.type=="Ridge") {
+	    penalty = 0
+	    if (nOP>1) { penalty = penalty + sum((params[2:nOP])^2) }
+	    if (nDP>1) { penalty = penalty + sum((params[(nOP+2):nP])^2) }
+	    penalty = penalty*lambda*0.5
+	  } else if (pen.type=="MPLE") {
+	    penalty = abs(params[1:nOP]-LRparams$coefficients)
+	    penalty = sum(penalty)*lambda
+	  } else {
+	    stop("pen.type not found")
+	  }
+	  penLL = sum(loglik) - penalty
+	  return(-penLL)
+        }
+    } # end if (engine)
+
+    fm <- optim(starts, nll, method = method, hessian = FALSE, ...)
+    opt <- fm
+    covMat <- matrix(NA, nP, nP)
+
+    ests <- fm$par
+    fmAIC <- 2 * fm$value + 2 * nP #+ 2*nP*(nP + 1)/(M - nP - 1)
+    names(ests) <- c(occParms, detParms)
+
+    state <- unmarkedEstimate(name = "Occupancy", short.name = "psi",
+                              estimates = ests[1:nOP],
+                              covMat = as.matrix(covMat[1:nOP,1:nOP]),
+                              invlink = "logistic",
+                              invlinkGrad = "logistic.grad")
+
+    det <- unmarkedEstimate(name = "Detection", short.name = "p",
+                            estimates = ests[(nOP + 1) : nP],
+                            covMat = as.matrix(covMat[(nOP + 1) : nP,
+                                                     (nOP + 1) : nP]),
+                            invlink = "logistic",
+                            invlinkGrad = "logistic.grad")
+
+    estimateList <- unmarkedEstimateList(list(state=state, det=det))
+
+    umfit <- new("unmarkedFitOccuPEN", fitType = "occu", call = match.call(),
+                 formula = formula, data = data,
+                 sitesRemoved = designMats$removed.sites,
+                 estimates = estimateList, AIC = fmAIC, opt = opt,
+                 negLogLike = fm$value,
+                 nllFun = nll, knownOcc = knownOccLog, 
+		 pen.type = pen.type, lambda = c(lambda))
+
+    return(umfit)
+}

--- a/R/unmarkedFit.R
+++ b/R/unmarkedFit.R
@@ -55,6 +55,24 @@ setClass("unmarkedFitOccu",
     representation(knownOcc = "logical"),
     contains = "unmarkedFit")
 
+setClass("unmarkedFitOccuPEN",
+    representation(
+	knownOcc = "logical",
+	pen.type = "character",
+	lambda = "numeric"),
+    contains = "unmarkedFit")
+
+setClass("unmarkedFitOccuPEN_CV",
+    representation(
+	knownOcc = "logical",
+	pen.type = "character",
+	lambdaVec = "numeric",
+	k = "numeric",
+	foldAssignments = "numeric",
+	lambdaScores = "numeric",
+	chosenLambda = "numeric"),
+    contains = "unmarkedFit")
+
 setClass("unmarkedFitOccuFP",
          representation(knownOcc = "logical",
             detformula = "formula",

--- a/inst/unitTests/runit.occuPEN.R
+++ b/inst/unitTests/runit.occuPEN.R
@@ -1,0 +1,157 @@
+test.occu.fit.simple.1 <- function() {
+  
+  y <- matrix(rep(1,10),5,2)
+  umf <- unmarkedFrameOccu(y = y)
+  fm <- occuPEN(~ 1 ~ 1, data = umf)
+
+  occ <- fm['state']
+  det <- fm['det']
+
+  occ <- coef(backTransform(occ))
+  checkEqualsNumeric(occ,1)
+
+  det <- coef(backTransform(det))
+  checkEqualsNumeric(det,1)
+
+  bt <- backTransform(fm, type = 'state')
+  checkEqualsNumeric(coef(bt), 1)
+
+  bt <- backTransform(fm, type = 'det')
+  checkEqualsNumeric(coef(bt), 1)
+
+}
+
+test.occu.fit.simple.0 <- function() {
+
+  y <- matrix(rep(0,10),5,2)
+  umf <- unmarkedFrameOccu(y = y)
+  fm <- occuPEN(~ 1 ~ 1, data = umf)
+
+  occ <- fm['state']
+  det <- fm['det']
+
+  occ <- coef(backTransform(occ))
+  checkEqualsNumeric(occ, 0, tolerance = 1e-4)
+
+  det <- coef(backTransform(det))
+  checkEqualsNumeric(det,0, tolerance = 1e-4)
+
+  bt <- backTransform(fm, type = 'state')
+  checkEqualsNumeric(coef(bt), 0, tolerance = 1e-4)
+
+  bt <- backTransform(fm, type = 'det')
+  checkEqualsNumeric(coef(bt), 0, tolerance = 1e-4)
+
+
+}
+
+test.occu.fit.covs <- function() {
+
+  y <- matrix(rep(0:1,10),5,2)
+  siteCovs <- data.frame(x = c(0,2,3,4,1))
+  obsCovs <- data.frame(o1 = 1:10, o2 = exp(-5:4)/10)
+  umf <- unmarkedFrameOccu(y = y, siteCovs = siteCovs, obsCovs = obsCovs)
+  fm <- occuPEN(~ o1 + o2 ~ x, data = umf)
+  fm1 <- occuPEN(~ o1 + o2 ~ x, data = umf,lambda=1,pen.type="Bayes")
+  fm2 <- occuPEN(~ o1 + o2 ~ x, data = umf,lambda=1,pen.type="Ridge")
+  MPLEla <- computeMPLElambda(~ o1 + o2 ~ x, data = umf)
+  fm3 <- occuPEN(~ o1 + o2 ~ x, data = umf,lambda=MPLEla,pen.type="MPLE")
+  
+  occ <- fm['state']
+  det <- fm['det']
+
+  occ1 <- fm1['state']
+  det1 <- fm1['det']
+
+  occ2 <- fm2['state']
+  det2 <- fm2['det']
+
+  occ3 <- fm3['state']
+  det3 <- fm3['det']
+
+  checkException(occ <- coef(backTransform(occ)))
+
+  checkEqualsNumeric(coef(occ), c(8.590737, 2.472220), tolerance = 1e-4)
+  checkEqualsNumeric(coef(det), c(0.44457, -0.14706, 0.44103), tolerance = 1e-4)
+
+  checkEqualsNumeric(coef(occ1), c(0.7171743, 0.6977753), tolerance = 1e-4)
+  checkEqualsNumeric(coef(det1), c(0.08143832, -0.06451574,  0.28695210), tolerance = 1e-4)
+
+  checkEqualsNumeric(coef(occ2), c(1.009337e+01,  4.329662e-04), tolerance = 1e-4)
+  checkEqualsNumeric(coef(det2), c(0.25892308, -0.09459618,  0.31092107), tolerance = 1e-4)
+
+  checkEqualsNumeric(coef(occ3), c(8.590738, 2.472220), tolerance = 1e-4)
+  checkEqualsNumeric(coef(det3), c(0.4445733, -0.1470601,  0.4410251), tolerance = 1e-4)
+
+  occ.lc <- linearComb(fm, type = 'state', c(1, 0.5))
+  det.lc <- linearComb(fm, type = 'det', c(1, 0.3, -0.3))
+    
+  checkEqualsNumeric(coef(occ.lc), 9.826848, tol = 1e-4)
+  checkEqualsNumeric(coef(det.lc), 0.2681477, tol = 1e-4)
+
+  checkEqualsNumeric(coef(backTransform(occ.lc)), 1, tol = 1e-4)
+  checkEqualsNumeric(coef(backTransform(det.lc)), 0.5666381, tol = 1e-4)
+
+  checkException(backTransform(fm, type = "state"))
+  checkException(backTransform(fm, type = "det"))
+
+  fitted <- fitted(fm)
+  checkEqualsNumeric(fitted, structure(c(0.5738, 0.5014, 0.4318, 0.38581, 0.50171, 0.53764, 
+0.46563, 0.40283, 0.39986, 0.79928), .Dim = c(5L, 2L)), tol = 1e-5)
+
+  checkException(occuPEN_CV(~ o1 + o2 ~ x, data = umf, k=15))
+  fmCV <- occuPEN_CV(~ o1 + o2 ~ x, data = umf)
+  checkEqualsNumeric(fmCV@chosenLambda, 1, tol = 1e-4)
+  checkEqualsNumeric(fmCV@lambdaScores, c(31.423777, 15.603297, 12.330360, 10.130768,  8.981720,  8.572523,  8.572841, 8.798436,  9.153270,  9.543802), tol = 1e-4)
+
+}
+
+test.occu.fit.covs.0 <- function() {
+
+  y <- matrix(rep(0:1,10),5,2)
+  siteCovs <- data.frame(x = c(0,2,3,4,1))
+  obsCovs <- data.frame(o1 = 1:10, o2 = exp(-5:4)/10)
+  umf <- unmarkedFrameOccu(y = y, siteCovs = siteCovs, obsCovs = obsCovs)
+  checkEqualsNumeric(computeMPLElambda(~ o1 + o2 ~ x, data = umf),4.017164e-11)
+  checkException(fm <- occuPEN(~ o1 + o2 ~ x, data = umf,pen.type="none"))
+  checkException(fm <- occuPEN(~ o1 + o2 ~ 1, data = umf,pen.type="MPLE"))
+  checkException(fm <- occuPEN(~ 1 ~ 1, data = umf,pen.type="Ridge"))
+  checkException(fm <- occuPEN_CV(~ o1 + o2 ~ x, data = umf,lambda=c(0)))
+  checkException(fm <- occuPEN_CV(~ o1 + o2 ~ x, data = umf,foldAssignments=c(1,2,3,4,5),k=6))
+}
+
+test.occu.fit.NA <- function() {
+
+  y <- matrix(rep(0:1,10),5,2)
+  siteCovs <- data.frame(x = c(0,2,3,4,1))
+  siteCovs[3,1] <- NA
+  obsCovs <- data.frame(o1 = 1:10, o2 = exp(-5:4)/10)
+  umf <- unmarkedFrameOccu(y = y, siteCovs = siteCovs, obsCovs = obsCovs)
+  fm <- occuPEN(~ o1 + o2 ~ x, data = umf)
+  checkEquals(fm@sitesRemoved, 3)
+  checkEqualsNumeric(coef(fm), c(8.70123, 4.58255, 0.66243, -0.22862, 0.58192), tol = 1e-5)
+
+  obsCovs[10,2] <- NA
+  umf <- unmarkedFrameOccu(y = y, siteCovs = siteCovs, obsCovs = obsCovs)
+  fm <- occuPEN(~ o1 + o2 ~ x, data = umf)
+  checkEquals(fm@sitesRemoved, 3)
+  checkEqualsNumeric(coef(fm), c(8.91289, 1.89291, -1.42471, 0.67011, -8.44608), tol = 1e-5)
+
+}
+
+## Add some checks here.
+test.occu.offest <- function() {
+
+  y <- matrix(rep(0:1,10),5,2)
+  siteCovs <- data.frame(x = c(0,2,3,4,1))
+  obsCovs <- data.frame(o1 = 1:10, o2 = exp(-5:4)/10)
+  umf <- unmarkedFrameOccu(y = y, siteCovs = siteCovs, obsCovs = obsCovs)
+  fm <- occuPEN(~ o1 + o2 ~ offset(x), data = umf)
+  checkEqualsNumeric(coef(fm),
+                     structure(c(9.74361, 0.44327, -0.14683, 0.44085), .Names = c("psi(Int)", 
+"p(Int)", "p(o1)", "p(o2)")), tol = 1e-5)
+  fm <- occuPEN(~ o1 + offset(o2) ~ offset(x), data = umf)
+  checkEqualsNumeric(coef(fm), structure(c(8.59459, 0.97574, -0.3096), .Names = c("psi(Int)", 
+"p(Int)", "p(o1)")), tol=1e-5)
+
+}

--- a/man/computeMPLElambdas.Rd
+++ b/man/computeMPLElambdas.Rd
@@ -1,0 +1,48 @@
+\name{computeMPLElambda}
+
+\alias{computeMPLElambda}
+
+\title{Compute the penalty weight for the MPLE penalized likelihood method}
+
+\usage{computeMPLElambda(formula, data, knownOcc=numeric(0), starts, method="BFGS", engine=c("C", "R"))}
+
+\arguments{
+    \item{formula}{Double right-hand side formula describing covariates of
+        detection and occupancy in that order.}
+    \item{data}{An \code{\link{unmarkedFrameOccu}} object}
+    \item{knownOcc}{Vector of sites that are known to be occupied. These
+    should be supplied as row numbers of the y matrix, eg, c(3,8) if
+    sites 3 and 8 were known to be occupied a priori.}
+    \item{starts}{Vector of parameter starting values.}
+    \item{method}{Optimization method used by \code{\link{optim}}.}
+    \item{engine}{Either "C" or "R" to use fast C++ code or native R
+      code during the optimization.}
+    \item{\dots}{Additional arguments to optim, such as lower and upper
+      bounds}
+  }
+
+\description{This function computes the weight for the MPLE penalty of Moreno & Lele (2010). }
+
+\details{
+
+See \code{\link{occuPEN}} for details and examples.
+
+}
+
+\value{The computed lambda.}
+
+\references{
+
+Moreno, M. and S. R. Lele. 2010. Improved estimation of site occupancy
+using penalized likelihood. Ecology 91: 341-346.
+
+}
+
+\author{Rebecca A. Hutchinson}
+
+\seealso{\code{\link{unmarked}}, \code{\link{unmarkedFrameOccu}},
+    \code{\link{occu}}, \code{\link{occuPEN}}, \code{\link{occuPEN_CV}}, 
+    \code{\link{nonparboot}}}
+
+
+\keyword{models}

--- a/man/nonparboot-methods.Rd
+++ b/man/nonparboot-methods.Rd
@@ -7,6 +7,8 @@
 \alias{nonparboot,unmarkedFitDS-method}
 \alias{nonparboot,unmarkedFitMPois-method}
 \alias{nonparboot,unmarkedFitOccu-method}
+\alias{nonparboot,unmarkedFitOccuPEN-method}
+\alias{nonparboot,unmarkedFitOccuPEN_CV-method}
 \alias{nonparboot,unmarkedFitOccuRN-method}
 \alias{nonparboot,unmarkedFitPCount-method}
 \alias{nonparboot,unmarkedFitGDS-method}
@@ -35,6 +37,12 @@ get bootstrap estimates of standard errors.
 
 \item{\code{signature(object = "unmarkedFitOccu")}}{  Obtain nonparametric
   bootstrap samples for a occu fits. }
+
+\item{\code{signature(object = "unmarkedFitOccuPEN")}}{  Obtain nonparametric
+  bootstrap samples for an occuPEN fit. }
+
+\item{\code{signature(object = "unmarkedFitOccuPEN_CV")}}{  Obtain nonparametric
+  bootstrap samples for occuPEN_CV fit. }
 
 \item{\code{signature(object = "unmarkedFitOccuRN")}}{  Obtain nonparametric
   bootstrap samples for a occuRN fits. }

--- a/man/occuPEN.Rd
+++ b/man/occuPEN.Rd
@@ -52,7 +52,8 @@ one computed with this equation, the supplied value is used anyway
 
 Hutchinson, R. A., J. V. Valente, S. C. Emerson, M. G. Betts, and
 T. G. Dietterich. 2015. Penalized Likelihood Methods Improve Parameter
-Estimates in Occupancy Models. in preparation.
+Estimates in Occupancy Models. Methods in Ecology and Evolution. DOI:
+10.1111/2041-210X.12368
 
 MacKenzie, D. I., J. D. Nichols, G. B. Lachman, S. Droege,
   J. Andrew Royle, and C. A. Langtimm. 2002. Estimating Site Occupancy Rates

--- a/man/occuPEN.Rd
+++ b/man/occuPEN.Rd
@@ -1,0 +1,122 @@
+\name{occuPEN}
+
+\alias{occuPEN}
+
+\title{Fit the MacKenzie et al. (2002) Occupancy Model with the penalized likelihood methods of Hutchinson et al. (2015)}
+
+\usage{occuPEN(formula, data, knownOcc=numeric(0), starts, method="BFGS",
+    engine=c("C", "R"), lambda=0, pen.type = c("Bayes","Ridge","MPLE"), ...)}
+
+\arguments{
+    \item{formula}{Double right-hand side formula describing covariates of
+        detection and occupancy in that order.}
+    \item{data}{An \code{\link{unmarkedFrameOccu}} object}
+    \item{knownOcc}{Vector of sites that are known to be occupied. These
+    should be supplied as row numbers of the y matrix, eg, c(3,8) if
+    sites 3 and 8 were known to be occupied a priori.}
+    \item{starts}{Vector of parameter starting values.}
+    \item{method}{Optimization method used by \code{\link{optim}}.}
+    \item{engine}{Either "C" or "R" to use fast C++ code or native R
+      code during the optimization.}
+    \item{lambda}{Penalty weight parameter.}
+    \item{pen.type}{Which form of penalty to use.}
+    \item{\dots}{Additional arguments to optim, such as lower and upper
+      bounds}
+  }
+
+\description{This function fits the occupancy model of MacKenzie et al (2002) with the penalized methods of Hutchinson et al (2015).}
+
+\details{
+
+See \code{\link{unmarkedFrame}} and \code{\link{unmarkedFrameOccu}} for a
+description of how to supply data to the \code{data} argument.
+
+\code{occuPEN} fits the standard occupancy model based on
+zero-inflated binomial models (MacKenzie et al. 2006, Royle and
+Dorazio 2008) using the penalized likelihood methods described in
+Hutchinson et al. (2015).  See \code{\link{occu}} for model
+details. \code{occuPEN} returns parameter estimates that maximize a
+penalized likelihood in which the penalty is specified by the
+\code{pen.type} argument. The penalty function is weighted by
+\code{lambda}. 
+
+The MPLE method includes an equation for computing \code{lambda}
+(Moreno & Lele, 2010). If the value supplied does not equal match the
+one computed with this equation, the supplied value is used anyway
+(with a warning).
+}
+
+\value{unmarkedFitOccuPEN object describing the model fit.}
+
+\references{
+
+Hutchinson, R. A., J. V. Valente, S. C. Emerson, M. G. Betts, and
+T. G. Dietterich. 2015. Penalized Likelihood Methods Improve Parameter
+Estimates in Occupancy Models. in preparation.
+
+MacKenzie, D. I., J. D. Nichols, G. B. Lachman, S. Droege,
+  J. Andrew Royle, and C. A. Langtimm. 2002. Estimating Site Occupancy Rates
+  When Detection Probabilities Are Less Than One. Ecology 83: 2248-2255.
+
+MacKenzie, D. I. et al. 2006. \emph{Occupancy Estimation and Modeling}.
+  Amsterdam: Academic Press.
+
+Moreno, M. and S. R. Lele. 2010. Improved estimation of site occupancy
+using penalized likelihood. Ecology 91: 341-346.
+
+Royle, J. A. and R. Dorazio. 2008. \emph{Hierarchical Modeling and Inference
+  in Ecology}. Academic Press.
+
+}
+
+\author{Rebecca A. Hutchinson}
+
+\seealso{\code{\link{unmarked}}, \code{\link{unmarkedFrameOccu}},
+    \code{\link{occu}}, \code{\link{computeMPLElambda}}, 
+    \code{\link{occuPEN_CV}}, \code{\link{nonparboot}}}
+
+
+\examples{
+
+# Simulate occupancy data
+set.seed(344)
+nSites <- 100
+nReps <- 2
+covariates <- data.frame(veght=rnorm(nSites),
+    habitat=factor(c(rep('A', nSites/2), rep('B', nSites/2))))
+
+psipars <- c(-1, 1, -1)
+ppars <- c(1, -1, 0)
+X <- model.matrix(~veght+habitat, covariates) # design matrix
+psi <- plogis(X \%*\% psipars)
+p <- plogis(X \%*\% ppars)
+
+y <- matrix(NA, nSites, nReps)
+z <- rbinom(nSites, 1, psi)       # true occupancy state
+for(i in 1:nSites) {
+    y[i,] <- rbinom(nReps, 1, z[i]*p[i])
+    }
+
+# Organize data and look at it
+umf <- unmarkedFrameOccu(y = y, siteCovs = covariates)
+obsCovs(umf) <- covariates
+head(umf)
+summary(umf)
+
+# Fit some models
+fmMLE <- occu(~veght+habitat ~veght+habitat, umf)
+fm1pen <- occuPEN(~veght+habitat ~veght+habitat, umf,lambda=0.33,pen.type="Ridge")
+fm2pen <- occuPEN(~veght+habitat ~veght+habitat, umf,lambda=1,pen.type="Bayes")
+
+# MPLE:
+fm3pen <- occuPEN(~veght+habitat ~veght+habitat, umf,lambda=0.5,pen.type="MPLE")
+MPLElambda = computeMPLElambda(~veght+habitat ~veght+habitat, umf) 
+fm4pen <- occuPEN(~veght+habitat ~veght+habitat, umf,lambda=MPLElambda,pen.type="MPLE")
+
+# nonparametric bootstrap for uncertainty analysis:
+fm1pen <- nonparboot(fm1pen,B=20) # should use more samples
+vcov(fm1pen,method="nonparboot")
+
+}
+
+\keyword{models}

--- a/man/occuPEN_CV.Rd
+++ b/man/occuPEN_CV.Rd
@@ -58,7 +58,8 @@ across runs; to eliminate the randomness, supply foldAssignments.
 
 Hutchinson, R. A., J. V. Valente, S. C. Emerson, M. G. Betts, and
 T. G. Dietterich. 2015. Penalized Likelihood Methods Improve Parameter
-Estimates in Occupancy Models. in preparation.
+Estimates in Occupancy Models. Methods in Ecology and Evolution. DOI:
+10.1111/2041-210X.12368
 
 MacKenzie, D. I., J. D. Nichols, G. B. Lachman, S. Droege,
   J. Andrew Royle, and C. A. Langtimm. 2002. Estimating Site Occupancy Rates

--- a/man/occuPEN_CV.Rd
+++ b/man/occuPEN_CV.Rd
@@ -1,0 +1,128 @@
+\name{occuPEN_CV}
+
+\alias{occuPEN_CV}
+
+\title{Fit the MacKenzie et al. (2002) Occupancy Model with the penalized likelihood methods of Hutchinson et al. (2015) using cross-validation}
+
+\usage{occuPEN_CV(formula, data, knownOcc=numeric(0), starts, method="BFGS",
+    engine=c("C", "R"), lambdaVec=c(0,2^seq(-4,4)),
+    pen.type = c("Bayes","Ridge"), k = 5, foldAssignments = NA,
+    ...)}
+
+\arguments{
+    \item{formula}{Double right-hand side formula describing covariates of
+        detection and occupancy in that order.}
+    \item{data}{An \code{\link{unmarkedFrameOccu}} object}
+    \item{knownOcc}{Vector of sites that are known to be occupied. These
+    should be supplied as row numbers of the y matrix, eg, c(3,8) if
+    sites 3 and 8 were known to be occupied a priori.}
+    \item{starts}{Vector of parameter starting values.}
+    \item{method}{Optimization method used by \code{\link{optim}}.}
+    \item{engine}{Either "C" or "R" to use fast C++ code or native R
+      code during the optimization.}
+    \item{lambdaVec}{Vector of values to try for lambda.}
+    \item{pen.type}{Which form of penalty to use.}
+    \item{k}{Number of folds for k-fold cross-validation.}
+    \item{foldAssignments}{Vector containing the number of the fold
+      that each site falls into. Length of the vector should be equal
+      to the number of sites, and the vector should contain k unique
+      values. E.g. for 9 sites and 3 folds, c(1,2,3,1,2,3,1,2,3) or
+      c(1,1,1,2,2,2,3,3,3).}
+    \item{\dots}{Additional arguments to optim, such as lower and upper
+      bounds}
+  }
+
+\description{This function fits the occupancy model of MacKenzie et al
+(2002) with the penalized methods of Hutchinson et al (2015) using
+k-fold cross-validation to choose the penalty weight.}
+
+\details{
+
+See \code{\link{unmarkedFrame}} and \code{\link{unmarkedFrameOccu}} for a
+description of how to supply data to the \code{data} argument.
+
+This function wraps k-fold cross-validation around \code{occuPEN_CV}
+for the "Bayes" and "Ridge" penalties of Hutchinson et al. (2015). The
+user may specify the number of folds (\code{k}), the values to try
+(\code{lambdaVec}), and the assignments of sites to folds
+(\code{foldAssignments}). If \code{foldAssignments} is not provided,
+the assignments are done pseudo-randomly, and the function attempts to
+put some sites with and without positive detections in each fold. This
+randomness introduces variability into the results of this function
+across runs; to eliminate the randomness, supply foldAssignments. 
+}
+
+\value{unmarkedFitOccuPEN_CV object describing the model fit.}
+
+\references{
+
+Hutchinson, R. A., J. V. Valente, S. C. Emerson, M. G. Betts, and
+T. G. Dietterich. 2015. Penalized Likelihood Methods Improve Parameter
+Estimates in Occupancy Models. in preparation.
+
+MacKenzie, D. I., J. D. Nichols, G. B. Lachman, S. Droege,
+  J. Andrew Royle, and C. A. Langtimm. 2002. Estimating Site Occupancy Rates
+  When Detection Probabilities Are Less Than One. Ecology 83: 2248-2255.
+
+}
+
+\author{Rebecca A. Hutchinson}
+
+\seealso{\code{\link{unmarked}}, \code{\link{unmarkedFrameOccu}},
+    \code{\link{occu}}, \code{\link{occuPEN}}, \code{\link{nonparboot}}}
+
+
+\examples{
+
+# Simulate occupancy data
+set.seed(646)
+nSites <- 60
+nReps <- 2
+covariates <- data.frame(veght=rnorm(nSites),
+    habitat=factor(c(rep('A', 30), rep('B', 30))))
+
+psipars <- c(-1, 1, -1)
+ppars <- c(1, -1, 0)
+X <- model.matrix(~veght+habitat, covariates) # design matrix
+psi <- plogis(X \%*\% psipars)
+p <- plogis(X \%*\% ppars)
+
+y <- matrix(NA, nSites, nReps)
+z <- rbinom(nSites, 1, psi)       # true occupancy state
+for(i in 1:nSites) {
+    y[i,] <- rbinom(nReps, 1, z[i]*p[i])
+    }
+
+# Organize data and look at it
+umf <- unmarkedFrameOccu(y = y, siteCovs = covariates)
+obsCovs(umf) <- covariates
+head(umf)
+summary(umf)
+
+# Fit some models
+fmMLE <- occu(~veght+habitat ~veght+habitat, umf)
+fmMLE@estimates
+
+fm1penCV <- occuPEN_CV(~veght+habitat ~veght+habitat, umf,pen.type="Ridge",foldAssignments=rep(1:5,ceiling(nSites/5))[1:nSites])
+fm1penCV@lambdaVec
+fm1penCV@chosenLambda
+fm1penCV@estimates
+
+fm2penCV <- occuPEN_CV(~veght+habitat ~veght+habitat, umf,pen.type="Bayes",foldAssignments=rep(1:5,ceiling(nSites/5))[1:nSites])
+fm2penCV@lambdaVec
+fm2penCV@chosenLambda
+fm2penCV@estimates
+
+# nonparametric bootstrap for uncertainty analysis:
+# bootstrap is wrapped around the cross-validation
+fm2penCV <- nonparboot(fm2penCV,B=10) # should use more samples
+vcov(fm2penCV,method="nonparboot")
+
+# Mean squared error of parameters:
+mean((c(psipars,ppars)-c(fmMLE[1]@estimates,fmMLE[2]@estimates))^2)
+mean((c(psipars,ppars)-c(fm1penCV[1]@estimates,fm1penCV[2]@estimates))^2)
+mean((c(psipars,ppars)-c(fm2penCV[1]@estimates,fm2penCV[2]@estimates))^2)
+
+}
+
+\keyword{models}

--- a/man/unmarkedFit-class.Rd
+++ b/man/unmarkedFit-class.Rd
@@ -27,6 +27,8 @@
 \alias{sampleSize}
 \alias{sampleSize,unmarkedFit-method}
 \alias{unmarkedFitOccu-class}
+\alias{unmarkedFitOccuPEN-class}
+\alias{unmarkedFitOccuPEN_CV-class}
 \alias{unmarkedFitOccuFP-class}
 \alias{unmarkedFitPCount-class}
 \alias{unmarkedFitDS-class}

--- a/src/nll_occuPEN.cpp
+++ b/src/nll_occuPEN.cpp
@@ -1,0 +1,43 @@
+#include "nll_occuPEN.h"
+
+using namespace Rcpp ;
+
+SEXP nll_occuPEN( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_psiR, SEXP beta_pR, SEXP ndR, SEXP knownOccR, SEXP navecR, SEXP X_offsetR, SEXP V_offsetR, SEXP penaltyR ) {
+  arma::icolvec y = as<arma::icolvec>(yR);
+  arma::mat X = as<arma::mat>(Xr);
+  arma::mat V = as<arma::mat>(Vr);
+  arma::colvec beta_psi = as<arma::colvec>(beta_psiR);
+  arma::colvec beta_p = as<arma::colvec>(beta_pR);
+  Rcpp::IntegerVector nd(ndR);
+  Rcpp::LogicalVector knownOcc(knownOccR);
+  Rcpp::LogicalVector navec(navecR);
+  arma::colvec X_offset = as<arma::colvec>(X_offsetR);
+  arma::colvec V_offset = as<arma::colvec>(V_offsetR);
+  //std::double penalty = as<std::double>(penaltyR);
+  double penalty = as<double>(penaltyR);
+  int R = X.n_rows;
+  int J = y.n_elem / R;
+  arma::colvec logit_psi = X*beta_psi + X_offset;
+  arma::colvec logit_p = V*beta_p + V_offset;
+  arma::colvec psi = 1.0/(1.0+exp(-logit_psi));
+  arma::colvec p = 1.0/(1.0+exp(-logit_p));
+  double ll=0.0;
+  int k=0; // counter
+  for(int i=0; i<R; i++) {
+    double cp=1.0;
+    for(int j=0; j<J; j++) {
+      if(!navec(k))
+	cp *= pow(p(k),y(k)) * pow(1-p(k), 1-y(k));
+      k++;
+    }
+    if(knownOcc(i))
+      psi(i) = 1.0;
+    if(nd(i)==0)
+      ll += log(cp * psi(i) + DOUBLE_XMIN);
+    else if(nd(i)==1)
+      ll += log(cp * psi(i) + (1-psi(i)) + DOUBLE_XMIN);
+  }
+  ll = ll - penalty;
+  return wrap(-ll);
+}
+

--- a/src/nll_occuPEN.h
+++ b/src/nll_occuPEN.h
@@ -1,0 +1,8 @@
+#ifndef _unmarked_NLL_OCCUPEN_H
+#define _unmarked_NLL_OCCUPEN_H
+
+#include <RcppArmadillo.h>
+
+RcppExport SEXP nll_occuPEN( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_psiR, SEXP beta_pR, SEXP ndR, SEXP knownOccR, SEXP navecR, SEXP X_offsetR, SEXP V_offsetR, SEXP penaltyR ) ;
+
+#endif


### PR DESCRIPTION
This branch contains code for estimating occupancy model parameters with penalized likelihood methods, as described in a manuscript in submission. occuPEN.R contains functions to run the penalized methods with and without cross-validation, and the interface is very similar to the existing occupancy modeling functions. The documentation and examples have been updated as well. 