### PR TITLE
formatMult no longer corrupts covariates when factors are present; fixes #47

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -333,6 +333,10 @@ formatMult <- function(df.in)
     dfnm <- colnames(df.obs)
     nV <- length(dfnm) - 1  # last variable is obsNum
 
+    ### Identify variables that are not factors
+    fac <- sapply(df.obs[, 5:nV], is.factor)
+    nonfac <- names(df.obs[, 5:nV])[!fac]
+    
     # create y matrix using reshape
     expr <- substitute(recast(df.obs, var1 ~ year + obsNum + variable,
                               id.var = c(dfnm[2],"year","obsNum"),
@@ -353,6 +357,15 @@ formatMult <- function(df.in)
     y <- as.matrix(y)
 
     obsvars.list <- arrToList(obsvars)
+    
+    # Return any non-factors to the correct mode
+    if (length(nonfac) >= 1) {
+      modes <- apply(df.obs[, nonfac], 2, mode)
+      for (i in 1:length(nonfac)) {
+        mode(obsvars.list[[nonfac[i]]]) <- modes[i]
+      }
+    }
+    
     obsvars.list <- lapply(obsvars.list, function(x) as.vector(t(x)))
     obsvars.df <- as.data.frame(obsvars.list)
 

--- a/inst/unitTests/runit.utils.R
+++ b/inst/unitTests/runit.utils.R
@@ -5,4 +5,60 @@ test.formatLong <- function() {
 }
 
 
+test.formatMult <- function() {
+  test <- expand.grid.df(expand.grid(site = LETTERS[1:4], visit = 1:3), 
+                         data.frame(year = 2015:2016))
+  test <- test[with(test, order(site, year, visit)), ]
+  test <- test[, c("year", "site", "visit")]
+  
+  set.seed(18939)
+  test <- within(test, {
+    ocov = round(rnorm(nrow(test)), 2)
+    scov = 2 * as.numeric(test$site)
+    yscov = 1.3 * as.numeric(interaction(test$site, test$year))
+    obsfac = factor(sample(LETTERS[1:2], nrow(test), replace = TRUE))
+    sitefac = factor(round(as.numeric(site)/5))
+    ysfac = factor(round(as.numeric(interaction(site, year))/10))
+    y  = rpois(nrow(test), lambda = 2)
+  })
 
+  withfac <- formatMult(test) 
+  
+  checkEquals(withfac,
+              new("unmarkedMultFrame"
+                  , numPrimary = 2L
+                  , yearlySiteCovs = structure(list(ysfac = structure(c(1L, 1L, 1L, 2L, 1L, 2L, 1L, 2L), 
+                                                                      .Label = c("0", "1"), class = "factor"), 
+                                                    yscov = c(1.3, 6.5, 2.6, 7.8, 3.9, 9.1, 5.2, 10.4)), 
+                                               .Names = c("ysfac", "yscov"), row.names = c(NA, -8L), class = "data.frame")
+                  , y = structure(c(0L, 1L, 3L, 3L, 2L, 2L, 2L, 1L, 1L, 0L, 3L, 3L, 1L, 
+                                    1L, 0L, 0L, 3L, 1L, 2L, 2L, 2L, 1L, 3L, 3L), .Dim = c(4L, 6L), .Dimnames = list(
+                                      structure(c("A", "B", "C", "D"), .Names = c("1", "43", "85", "127")), 
+                                      structure(c("2015-1", "2015-2", "2015-3", "2016-1", "2016-2", "2016-3"), 
+                                                .Names = c("1", "8", "15", "22", "29", "36"))))
+                  , obsCovs = structure(list(visit = structure(c(1L, 2L, 3L, 1L, 2L, 3L, 1L, 2L, 3L, 1L, 2L, 3L, 1L, 2L, 3L, 
+                                                                 1L, 2L, 3L, 1L, 2L, 3L, 1L, 2L, 3L), 
+                                                               .Label = c("1", "2", "3"), class = "factor"), 
+                                             ysfac = structure(c(1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 2L, 2L, 2L, 1L, 1L, 1L, 
+                                                                 2L, 2L, 2L, 1L, 1L, 1L, 2L, 2L, 2L), 
+                                                               .Label = c("0", "1"), class = "factor"), 
+                                             sitefac = structure(c(1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 2L, 2L, 2L, 
+                                                                   2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L, 2L), 
+                                                                 .Label = c("0", "1"), class = "factor"), 
+                                             obsfac = structure(c(2L, 1L, 1L, 1L, 2L, 2L, 2L, 1L, 1L, 1L, 2L, 1L, 2L, 2L, 1L, 
+                                                                  1L, 2L, 2L, 2L, 1L, 2L, 2L, 1L, 1L), .Label = c("A", "B"), class = "factor"), 
+                                             yscov = c(1.3, 1.3, 1.3, 6.5, 6.5, 6.5, 2.6, 2.6, 2.6, 7.8, 
+                                                       7.8, 7.8, 3.9, 3.9, 3.9, 9.1, 9.1, 9.1, 5.2, 5.2, 5.2, 10.4, 
+                                                       10.4, 10.4), 
+                                             scov = c(2, 2, 2, 2, 2, 2, 4, 4, 4, 4, 4, 4, 6, 6, 6, 6, 6, 6, 8, 8, 8, 8, 8, 8), 
+                                             ocov = c(0.28, -1.41, -0.31, 0.05, -0.53, 0.84, -0.95, 1.63, 0.87, 1.03, 1.41, 
+                                                      1.25, -0.32, 0.11, -0.45, -0.83, 0.17, 0.28, -0.13, -1.86, -1.82, 0.11, 1.29, -0.31)),
+                                        .Names = c("visit", "ysfac", "sitefac", "obsfac", "yscov", "scov", "ocov"), 
+                                        row.names = c(NA, -24L), class = "data.frame")
+                  , siteCovs = structure(list(sitefac = structure(c(1L, 1L, 2L, 2L), .Label = c("0", "1"), class = "factor"), 
+                                              scov = c(2, 4, 6, 8)), .Names = c("sitefac", "scov"), row.names = c(NA, -4L), class = "data.frame")
+                  , mapInfo = NULL
+                  , obsToY = structure(c(1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 
+                                         0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1), .Dim = c(6L, 6L))
+              ))
+}


### PR DESCRIPTION
```r
library(plyr); library(dplyr)
test <- expand.grid.df(expand.grid(site = LETTERS[1:10], visit = 1:3), 
                       data.frame(year = 2010:2012)) %>% arrange(site, year, visit) %>%
                       select(year, site, visit)
test <- test %>% mutate(
  y  = rpois(nrow(test), lambda = 2),
  ocov = rnorm(nrow(test)),
  scov = 2 * as.numeric(test$site),
  yscov = 1.3 * as.numeric(interaction(test$site, test$year)))

# All continuous
nofac <- formatMult(test)
str(nofac)

# Add factor variables to each group of variables (obsCovs, siteCovs, yearlysiteCovs)
test2 <- test %>% mutate(
  obsfac = factor(sample(LETTERS[1:2], nrow(test), replace = TRUE)),
  sitefac = factor(round_any(as.numeric(site), 5)),
  ysfac = factor(round_any(as.numeric(interaction(site, year)), 10))
)

withfac <- formatMult(test2) 
str(withfac)

# Only factor variables for each group variables (obsCovs, siteCovs, yearlysiteCovs)
test3 <- select(test2, -ocov, -scov, -yscov)
onlyfac <- formatMult(test3)
str(onlyfac)

(fm <- colext(~scov, ~1, ~1, ~ocov, nofac)) 
(fm2 <- colext(~scov + sitefac, ~1, ~1, ~ocov + obsfac + ysfac, withfac))  
(fm3 <- colext(~sitefac, ~1, ~1, ~obsfac + sitefac + ysfac, onlyfac))  
```