### PR TITLE
Fix formatMult conversion of julian date/visit to factor

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -334,8 +334,9 @@ formatMult <- function(df.in)
     nV <- length(dfnm) - 1  # last variable is obsNum
 
     ### Identify variables that are not factors
-    fac <- sapply(df.obs[, 5:nV], is.factor)
-    nonfac <- names(df.obs[, 5:nV])[!fac]
+    # Include julian date/visit in search as it is added back in later
+    fac <- sapply(df.obs[, c(3, 5:nV)], is.factor) 
+    nonfac <- names(df.obs[, c(3, 5:nV)])[!fac]
     
     # create y matrix using reshape
     expr <- substitute(recast(df.obs, var1 ~ year + obsNum + variable,

--- a/inst/unitTests/runit.utils.R
+++ b/inst/unitTests/runit.utils.R
@@ -28,31 +28,25 @@ test.formatMult <- function() {
               new("unmarkedMultFrame"
                   , numPrimary = 2L
                   , yearlySiteCovs = structure(list(ysfac = structure(c(1L, 1L, 1L, 2L, 1L, 2L, 1L, 
-                                                                        2L), .Label = c("0", "1"), class = "factor"), yscov = c(1.3, 
-                                                                                                                                6.5, 2.6, 7.8, 3.9, 9.1, 5.2, 10.4)), .Names = c("ysfac", "yscov"
-                                                                                                                                ), row.names = c(NA, -8L), class = "data.frame")
+                                                                        2L), .Label = c("0", "1"), class = "factor"), 
+                                                    yscov = c(1.3, 6.5, 2.6, 7.8, 3.9, 9.1, 5.2, 10.4)), 
+                                               .Names = c("ysfac", "yscov"), row.names = c(NA, -8L), class = "data.frame")
                   , y = structure(c(0L, 1L, 3L, 3L, 2L, 2L, 2L, 1L, 1L, 0L, 3L, 3L, 1L, 
                                     1L, 0L, 0L, 3L, 1L, 2L, 2L, 2L, 1L, 3L, 3L), .Dim = c(4L, 6L), .Dimnames = list(
-                                      structure(c("A", "B", "C", "D"), .Names = c("1", "43", "85", 
-                                                                                  "127")), structure(c("2015-1", "2015-2", "2015-3", "2016-1", 
-                                                                                                       "2016-2", "2016-3"), .Names = c("1", "8", "15", "22", "29", 
-                                                                                                                                       "36"))))
-                  , obsCovs = structure(list(visit = structure(c(1L, 2L, 3L, 1L, 2L, 3L, 1L, 
-                                                                 2L, 3L, 1L, 2L, 3L, 1L, 2L, 3L, 1L, 2L, 3L, 1L, 2L, 3L, 1L, 2L, 
-                                                                 3L), .Label = c("1", "2", "3"), class = "factor"), obsfac = structure(c(2L, 
-                                                                                                                                         1L, 1L, 1L, 2L, 2L, 2L, 1L, 1L, 1L, 2L, 1L, 2L, 2L, 1L, 1L, 2L, 
-                                                                                                                                         2L, 2L, 1L, 2L, 2L, 1L, 1L), .Label = c("A", "B"), class = "factor"), 
-                                             ocov = c(0.28, -1.41, -0.31, 0.05, -0.53, 0.84, -0.95, 1.63, 
-                                                      0.87, 1.03, 1.41, 1.25, -0.32, 0.11, -0.45, -0.83, 0.17, 
-                                                      0.28, -0.13, -1.86, -1.82, 0.11, 1.29, -0.31)), .Names = c("visit", 
-                                                                                                                 "obsfac", "ocov"), class = "data.frame", row.names = c(NA, -24L
-                                                                                                                 ))
-                  , siteCovs = structure(list(sitefac = structure(c(1L, 1L, 2L, 2L), .Label = c("0", 
-                                                                                                "1"), class = "factor"), scov = c(2, 4, 6, 8)), .Names = c("sitefac", 
-                                                                                                                                                           "scov"), row.names = c(NA, -4L), class = "data.frame")
+                                      structure(c("A", "B", "C", "D"), .Names = c("1", "43", "85", "127")), 
+                                      structure(c("2015-1", "2015-2", "2015-3", "2016-1", "2016-2", "2016-3"), 
+                                                .Names = c("1", "8", "15", "22", "29", "36"))))
+                  , obsCovs = structure(list(visit = c(1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3), 
+                                             obsfac = structure(c(2L, 1L, 1L, 1L, 2L, 2L, 2L, 1L, 1L, 1L, 2L, 1L, 2L, 2L, 1L, 
+                                                                  1L, 2L,2L, 2L, 1L, 2L, 2L, 1L, 1L), .Label = c("A", "B"), class = "factor"), 
+                                             ocov = c(0.28, -1.41, -0.31, 0.05, -0.53, 0.84, -0.95, 1.63, 0.87, 1.03, 1.41, 
+                                                      1.25, -0.32, 0.11, -0.45, -0.83, 0.17, 0.28, -0.13, -1.86, -1.82, 0.11, 
+                                                      1.29, -0.31)), .Names = c("visit", "obsfac", "ocov"), 
+                                        class = "data.frame", row.names = c(NA, -24L))
+                  , siteCovs = structure(list(sitefac = structure(c(1L, 1L, 2L, 2L), .Label = c("0", "1"), class = "factor"), 
+                                              scov = c(2, 4, 6, 8)), .Names = c("sitefac", "scov"), row.names = c(NA, -4L), class = "data.frame")
                   , mapInfo = NULL
-                  , obsToY = structure(c(1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 
-                                         0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1), .Dim = c(6L, 
-                                                                                                            6L))
+                  , obsToY = structure(c(1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 
+                                         0, 0, 0, 0, 0, 0, 1), .Dim = c(6L, 6L))
               ))
 }


### PR DESCRIPTION
Fixed `formatMult` so that input Julian date (JD)/visit chronology information is not converted to factor when it is not, in fact, a factor.  When factor variables are present as additional covariates, the JD/visit chronology variable was coerced to a factor as the intermediate array could only store data with a single mode --- in this case a "character" mode subsequently converted into a factor.  Other non-factor variables are returned to their original mode.  The function now checks the the mode of the JD/visit variable and restores it to its original mode if not a factor.

Unit test updated as well.    