### PR TITLE
allow import of dataframes with multiple classes

### DIFF
--- a/R/unmarkedFrame.R
+++ b/R/unmarkedFrame.R
@@ -121,7 +121,7 @@ unmarkedFrame <- function(y, siteCovs = NULL, obsCovs = NULL, mapInfo,
     if(class(obsCovs) == "list") {
         obsVars <- names(obsCovs)
         for(i in seq(length(obsVars))) {
-            if(!(class(obsCovs[[i]]) %in% c("matrix", "data.frame")))
+            if(!(any(class(obsCovs[[i]]) %in% c("matrix", "data.frame"))))
                 stop("At least one element of obsCovs is not a matrix or data frame.")
             if(ncol(obsCovs[[i]]) != obsNum | nrow(obsCovs[[i]]) != nrow(y))
                 stop("At least one matrix in obsCovs has incorrect number of dimensions.")


### PR DESCRIPTION
Tweaks unmarkedFrame constructor so that obsCovs does not have to have matrix or dataframe as its *first* listed class, as long as it is a matrix or dataframe. If you decide not to do this to avoid a bunch of work accommodating tidyverse objects (I bet this is not the only place where this kind of thing comes up), you might consider including some advice in the documentation that would guide users towards the kind of workaround that I came up with e.g. using as.data.frame() to ensure that data.frame is the only class for the object provided to obsCovs. Closes #111