### PR TITLE
Transition to `reshape2` and allow pass-through arguments to `unmarkedFrame*` constructors if `formatLong`; add addn'l unit tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,4 +22,3 @@ URL: http://groups.google.com/group/unmarked,
      https://sites.google.com/site/unmarkedinfo/home,
      http://github.com/ianfiske/unmarked,
      http://github.com/rbchan/unmarked
-LinkingTo: Rcpp, RcppArmadillo

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Title: Models for Data from Unmarked Animals
 Author: Ian Fiske, Richard Chandler, David Miller, Andy Royle, Marc Kery, Jeff Hostetler, Rebecca Hutchinson 
 Maintainer: Andy Royle <aroyle@usgs.gov>
 Depends: R (>= 2.12.0), methods, lattice, parallel, Rcpp (>= 0.8.0), reshape2
-Imports: graphics, stats, utils, plyr, raster, reshape2
+Imports: graphics, stats, utils, plyr, raster
 Description: Fits hierarchical models of animal abundance and occurrence to data collected using survey methods such as point counts, site occupancy sampling, distance sampling, removal sampling, and double observer sampling. Parameters governing the state and observation processes can be modeled as functions of covariates.
 License: GPL (>=3)
 LazyLoad: yes

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,8 +5,8 @@ Type: Package
 Title: Models for Data from Unmarked Animals
 Author: Ian Fiske, Richard Chandler, David Miller, Andy Royle, Marc Kery, Jeff Hostetler, Rebecca Hutchinson 
 Maintainer: Andy Royle <aroyle@usgs.gov>
-Depends: R (>= 2.12.0), methods, reshape, lattice, parallel, Rcpp (>= 0.8.0)
-Imports: graphics, stats, utils, plyr, raster
+Depends: R (>= 2.12.0), methods, lattice, parallel, Rcpp (>= 0.8.0), reshape2
+Imports: graphics, stats, utils, plyr, raster, reshape2
 Description: Fits hierarchical models of animal abundance and occurrence to data collected using survey methods such as point counts, site occupancy sampling, distance sampling, removal sampling, and double observer sampling. Parameters governing the state and observation processes can be modeled as functions of covariates.
 License: GPL (>=3)
 LazyLoad: yes

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -9,17 +9,16 @@ importFrom(stats, confint, fitted, coef, vcov, predict, update, profile,
            update.formula)
 importFrom(graphics, plot, hist, abline)
 importFrom(utils, head, read.csv)
-importFrom(reshape, melt, cast, recast)
 importFrom(plyr, ldply, alply, ddply)
 importFrom(grDevices, devAskNewPage)
 importFrom("raster","stack")
 importFrom("raster", "raster", "extent", "extent<-", "getValues") ## MM
 
-import(lattice, methods, parallel, Rcpp)
+import(lattice, methods, parallel, Rcpp, reshape2)
 
 # Fitting functions
 export(occu, occuFP, occuRN, pcount, pcountOpen, multinomPois, distsamp,
-       colext, gmultmix, gdistsamp, gpcount, occuPEN, occuPEN_CV, 
+       colext, gmultmix, gdistsamp, gpcount, occuPEN, occuPEN_CV,
        computeMPLElambda, pcount.spHDS)
 export(removalPiFun, doublePiFun)
 

--- a/R/unmarkedFrame.R
+++ b/R/unmarkedFrame.R
@@ -691,8 +691,8 @@ setMethod("plot", c(x="unmarkedFrame", y="missing"),
     y$site <- 1:M
     sites.per.panel <- M/panels
     y$group <- as.factor(round(seq(1,panels,length=M)))
-    y2 <- melt(y, #measure.var = c("V1", "V2", "V3"),
-        id.var=c("site","group"))
+    y2 <- melt(y, #measure.vars = c("V1", "V2", "V3"),
+        id.vars=c("site","group"))
     if(missing(colorkey))
         colorkey <- list(at=0:(ym+1), labels=list(labels=as.character(0:ym),
             at=(0:ym)+0.5))
@@ -721,8 +721,6 @@ setMethod("hist", "unmarkedFrameDS", function(x, ...)
 setMethod("[", c("unmarkedFrame", "numeric", "missing", "missing"),
     function(x, i)
 {
-    if(!require(reshape))
-        stop("reshape package required")
     M <- numSites(x)
     if(length(i) == 0) return(x)
     if(any(i < 0) && any(i > 0))
@@ -759,8 +757,6 @@ setMethod("[", c("unmarkedFrame", "numeric", "missing", "missing"),
 setMethod("[", c("unmarkedFrame", "missing", "numeric", "missing"),
 		function(x, i, j)
 {
-    if(!require(reshape))
-        stop("reshape package required")
     y <- getY(x)
     obsCovs <- obsCovs(x)
     obsToY <- obsToY(x)
@@ -793,8 +789,6 @@ setMethod("[", c("unmarkedFrame","numeric", "numeric", "missing"),
 setMethod("[", c("unmarkedFrame","list", "missing", "missing"),
     function(x, i, j)
 {
-    if(!require(reshape))
-        stop("reshape package required")
     m <- numSites(x)
     J <- R <- obsNum(x)
     o2y <- obsToY(x)
@@ -858,8 +852,6 @@ setMethod("[", c("unmarkedMultFrame", "missing", "numeric", "missing"),
 setMethod("[", c("unmarkedMultFrame", "numeric", "missing", "missing"),
 		function(x, i, j)
 {
-    if(!require(reshape))
-        stop("reshape package required")
     M <- numSites(x)
     if(length(i) == 0) return(x)
     if(any(i < 0) && any(i > 0))

--- a/R/utils.R
+++ b/R/utils.R
@@ -171,7 +171,7 @@ dateToObs <- function(dfin)
 # date, one column
 # response, one column
 # obs vars, one per column
-formatLong <- function(dfin, species = NULL, type)
+formatLong <- function(dfin, species = NULL, type, ...)
 {
 
     if(missing(type)) stop("type must be supplied")
@@ -264,11 +264,11 @@ formatLong <- function(dfin, species = NULL, type)
     })
     siteCovs <- as.data.frame(siteCovs[!sapply(siteCovs, is.null)])
     if(nrow(siteCovs) == 0) siteCovs <- NULL
-    
+
     ## remove sitecovs from obsvars
     obsvars.df <- obsvars.df[, !(names(obsvars.df) %in% names(siteCovs)), drop = FALSE]
 
-    do.call(type, list(y = y, siteCovs = siteCovs, obsCovs = obsvars.df))
+    do.call(type, list(y = y, siteCovs = siteCovs, obsCovs = obsvars.df, ...))
 }
 
 # column names must be

--- a/R/utils.R
+++ b/R/utils.R
@@ -171,21 +171,21 @@ dateToObs <- function(dfin)
 # date, one column
 # response, one column
 # obs vars, one per column
-formatLong <- function(dfin, species = NULL, type, ...)
-{
+formatLong <- function(dfin, species = NULL, type, ...) {
+  if (type %in% c("umarkedFrameMPois", "unmarkedFrameGMM"))
+    stop("Multinomial data sets are not supported.")
+  if(missing(type)) stop("type must be supplied")
 
-    if(missing(type)) stop("type must be supplied")
+  ## copy dates to last column so that they are also a covdata var
+  nc <- ncol(dfin)
+  dfin[[nc+1]] <- dfin[[2]]
+  names(dfin)[nc+1] <- "Date"
 
-    ## copy dates to last column so that they are also a covdata var
-    nc <- ncol(dfin)
-    dfin[[nc+1]] <- dfin[[2]]
-    names(dfin)[nc+1] <- "Date"
-
-    if(!is.null(species)) {
-        dfin$y <- ifelse(dfin$species == species, dfin$y, 0)
-        dfin$y[is.na(dfin$y)] <- 0
-        dfin$species = NULL
-    }
+  if(!is.null(species)) {
+    dfin$y <- ifelse(dfin$species == species, dfin$y, 0)
+    dfin$y[is.na(dfin$y)] <- 0
+    dfin$species = NULL
+  }
 # TODO: dbl check that multiple cells per site*time are handled correctly.
 #  # sum up counts within time/site
 #  expr <- substitute(recast(dfin[,1:3], sv + dv ~ ..., id.var = 1:2,
@@ -281,8 +281,10 @@ formatLong <- function(dfin, species = NULL, type, ...)
 # site vars: namefoo, namebar, ...
 # obs v: namefoo.1, namefoo.2, ..., namefoo.J, namebar.1, .., namebar.J,..
 
-formatWide <- function(dfin, sep = ".", obsToY, type, ...)
-{
+formatWide <- function(dfin, sep = ".", obsToY, type, ...) {
+  if (type %in% c("umarkedFrameMPois", "unmarkedFrameGMM", "double", "removal"))
+    stop("Multinomial data sets are not supported.")
+
         # escape separater if it is regexp special
     reg.specials <- c('.', '\\', ':', '|', '(', ')', '[', '{', '^', '$',
                       '*', '+', '?')

--- a/R/utils.R
+++ b/R/utils.R
@@ -203,41 +203,43 @@ formatLong <- function(dfin, species = NULL, type)
     dfin <- dateToObs(dfin)
     dfnm <- colnames(dfin)
     nV <- length(dfnm) - 1  # last variable is obsNum
-    
+
     ### Identify variables that are not factors
     # Include julian date/visit in search as it is added back in later
-    fac <- sapply(dfin[, 4:nV], is.factor) 
-    nonfac <- names(dfin[, 4:nV])[!fac]
-    
-    expr <- substitute(recast(dfin, newvar ~ obsNum + variable,
-                              id.var = c(dfnm[1],"obsNum"),
-                              measure.var = dfnm[3]),
-                       list(newvar=as.name(dfnm[1])))
-    y <- as.matrix(eval(expr)[,-1])
-    attr(y,"class") <- "matrix"
+    fac <- sapply(dfin[, 4:nV, drop = FALSE], is.factor)
+    nonfac <- names(dfin[, 4:nV, drop = FALSE])[!fac]
 
-    expr <- substitute(recast(dfin, newvar ~ obsNum ~ variable,
-                              id.var = c(dfnm[1],"obsNum"),
-                              measure.var = dfnm[4:nV]),
+    expr <- substitute(acast(melt(dfin,
+                                  id.vars = c(dfnm[1],"obsNum"),
+                                  measure.vars = dfnm[3]),
+                             newvar ~ obsNum + variable),
+                       list(newvar=as.name(dfnm[1])))
+    y <- unname(eval(expr))
+
+    expr <- substitute(acast(melt(dfin,
+                                  id.vars = c(dfnm[1],"obsNum"),
+                                  measure.vars = dfnm[4:nV]),
+                             newvar ~ obsNum ~ variable),
                        list(newvar=as.name(dfnm[1])))
     obsvars <- eval(expr)
+    names(dimnames(obsvars)) <- list(dfnm[1], "obsNum", "variable")
     which.date <- which(dimnames(obsvars)$variable == "Date")
     dimnames(obsvars)$variable[which.date] <- "JulianDate"
 
     obsvars.matlist <- arrToList(obsvars)
     obsvars.veclist <- lapply(obsvars.matlist, function(x) as.vector(t(x)))
-    
+
     # Return any non-factors to the correct mode
     if (length(nonfac) >= 1) {
-      modes <- apply(dfin[, nonfac], 2, mode)
+      classes <- sapply(dfin[, nonfac], class)
       nonfac[which(nonfac == "Date")] <- "JulianDate"
       for (i in seq_along(nonfac)) {
-        mode(obsvars.veclist[[nonfac[i]]]) <- modes[i]
+        class(obsvars.veclist[[nonfac[i]]]) <- classes[i]
       }
     }
-    
+
     obsvars.df <- data.frame(obsvars.veclist)
-    
+
     ## check for siteCovs
     obsNum <- ncol(y)
     M <- nrow(y)
@@ -379,38 +381,37 @@ formatMult <- function(df.in)
 
     ### Identify variables that are not factors
     # Include julian date/visit in search as it is added back in later
-    fac <- sapply(df.obs[, c(3, 5:nV)], is.factor) 
-    nonfac <- names(df.obs[, c(3, 5:nV)])[!fac]
-    
+    fac <- sapply(df.obs[, c(3, 5:nV), drop = FALSE], is.factor)
+    nonfac <- names(df.obs[, c(3, 5:nV), drop = FALSE])[!fac]
+
     # create y matrix using reshape
-    expr <- substitute(recast(df.obs, var1 ~ year + obsNum + variable,
-                              id.var = c(dfnm[2],"year","obsNum"),
-                              measure.var = dfnm[4]),
+    expr <- substitute(acast(melt(df.obs,
+                                  id.vars = c(dfnm[2],"year","obsNum"),
+                                  measure.vars = dfnm[4]),
+                             var1 ~ year + obsNum + variable),
                        list(var1 = as.name(dfnm[2])))
-    y <- as.matrix(eval(expr)[,-1])
+    y <- unname(eval(expr))
 
     # create obsdata with reshape
     # include date (3rd col) and other measured vars
-    expr <- substitute(recast(df.obs, newvar ~ year + obsNum ~ variable,
-                              id.var = c(dfnm[2],"year","obsNum"),
-                              measure.var = dfnm[c(3,5:nV)]),
+    expr <- substitute(acast(melt(df.obs,
+                                  id.vars = c(dfnm[2],"year","obsNum"),
+                                  measure.vars = dfnm[c(3,5:nV)]),
+                             newvar ~ year + obsNum ~ variable),
                        list(newvar=as.name(dfnm[2])))
     obsvars <- eval(expr)
-
-    rownames(y) <- dimnames(obsvars)[[1]]
-    colnames(y) <- dimnames(obsvars)[[2]]
-    y <- as.matrix(y)
+    names(dimnames(obsvars)) <- list(dfnm[1], "obsNum", "variable")
 
     obsvars.list <- arrToList(obsvars)
-    
+
     # Return any non-factors to the correct mode
     if (length(nonfac) >= 1) {
-      modes <- apply(df.obs[, nonfac], 2, mode)
+      classes <- apply(df.obs[, nonfac], 2, class)
       for (i in 1:length(nonfac)) {
-        mode(obsvars.list[[nonfac[i]]]) <- modes[i]
+        class(obsvars.list[[nonfac[i]]]) <- classes[i]
       }
     }
-    
+
     obsvars.list <- lapply(obsvars.list, function(x) as.vector(t(x)))
     obsvars.df <- as.data.frame(obsvars.list)
 
@@ -471,7 +472,7 @@ formatMult <- function(df.in)
     finalobsvars.df <- as.data.frame(obsvars.df[, !(names(obsvars.df) %in%
                                                       c(names(siteCovs),
                                                         names(yearlySiteCovs)))])
-    names(finalobsvars.df) <- names(obsvars.df)[!(names(obsvars.df) %in% 
+    names(finalobsvars.df) <- names(obsvars.df)[!(names(obsvars.df) %in%
                                                     c(names(siteCovs),
                                                       names(yearlySiteCovs)))]
 
@@ -490,7 +491,7 @@ formatMult <- function(df.in)
 sppLongToWide <- function(df.in)
 {
     df.m <- melt(df.in, id = c("site", "spp"))
-    df.out <- cast(df.m, site ~ spp, add.missing=T, fill = 0)
+    df.out <- dcast(df.m, site ~ spp, add.missing=T, fill = 0)
     df.out <- df.out[order(df.out$site),]
     df.out
 }
@@ -593,16 +594,16 @@ as.numeric(1 - exp(-lambda))
 # Convert individual-level distance data to the
 # transect-level format required by distsamp()
 
-formatDistData <- function (distData, distCol, transectNameCol, dist.breaks, occasionCol,effortMatrix) 
+formatDistData <- function (distData, distCol, transectNameCol, dist.breaks, occasionCol,effortMatrix)
 {
-  if (!is.numeric(distData[, distCol])) 
+  if (!is.numeric(distData[, distCol]))
     stop("The distances must be numeric")
   transects <- distData[, transectNameCol]
   if (!is.factor(transects)) {
     transects <- as.factor(transects)
     warning("The transects were converted to a factor")
   }
-  
+
   if (missing(occasionCol)) {
     T <- 1
     occasions <- factor(rep(1, nrow(distData)))
@@ -620,29 +621,29 @@ formatDistData <- function (distData, distCol, transectNameCol, dist.breaks, occ
   if (missing(effortMatrix)) {
     effortMatrix <- matrix(nrow=M,ncol=T,1)
   }
-  
+
   if (!is.numeric(effortMatrix)){
     stop("effortMatrix is not numeric")
     effortMatrix <- matrix(nrow=M,ncol=T,1)
   }
-  
-  
-  dist.classes <- levels(cut(distData[, distCol], dist.breaks, 
+
+
+  dist.classes <- levels(cut(distData[, distCol], dist.breaks,
                              include.lowest = TRUE))
-  ya <- array(NA, c(M, J, T), dimnames = list(levels(transects), 
+  ya <- array(NA, c(M, J, T), dimnames = list(levels(transects),
                                               dist.classes, paste("rep", 1:T, sep = "")))
   transect.levels <- levels(transects)
   occasion.levels <- levels(occasions)
   for (i in 1:M) {
     for (t in 1:T) {
-      sub <- distData[transects == transect.levels[i] & 
+      sub <- distData[transects == transect.levels[i] &
                         occasions == occasion.levels[t], , drop = FALSE]
-      ya[i, , t] <- table(cut(sub[, distCol], dist.breaks, 
+      ya[i, , t] <- table(cut(sub[, distCol], dist.breaks,
                               include.lowest = TRUE))
     }
   }
   y <- matrix(ya, nrow = M, ncol = J * T)
-  # takes into account the effortMatrix to allow for the insertion of NAs instead of 0s for surveys which were not completed  
+  # takes into account the effortMatrix to allow for the insertion of NAs instead of 0s for surveys which were not completed
   ee <- array(NA, c(M,length(occasion.levels)*(length(dist.breaks)-1)))
   for(i in 1:length(occasion.levels)){
     ee[,((ncol(ee)/length(occasion.levels)*(i-1)+1):(ncol(ee)/length(occasion.levels)*i))] <- matrix(effortMatrix[,i], ncol=J, nrow=M)
@@ -651,7 +652,7 @@ formatDistData <- function (distData, distCol, transectNameCol, dist.breaks, occ
   y <- y * ee
   dn <- dimnames(ya)
   rownames(y) <- dn[[1]]
-  if (T == 1) 
+  if (T == 1)
     colnames(y) <- dn[[2]]
   else colnames(y) <- paste(rep(dn[[2]], times = T), rep(1:T, each = J), sep = "")
   return(y)

--- a/R/utils.R
+++ b/R/utils.R
@@ -268,7 +268,11 @@ formatLong <- function(dfin, species = NULL, type, ...)
     ## remove sitecovs from obsvars
     obsvars.df <- obsvars.df[, !(names(obsvars.df) %in% names(siteCovs)), drop = FALSE]
 
-    do.call(type, list(y = y, siteCovs = siteCovs, obsCovs = obsvars.df, ...))
+    if (type %in% c("unmarkedFrameDS", "unmarkedFrameGDS"))
+      # obsCovs cannot be used with distsamp
+      do.call(type, list(y = y, siteCovs = siteCovs, ...))
+    else
+      do.call(type, list(y = y, siteCovs = siteCovs, obsCovs = obsvars.df, ...))
 }
 
 # column names must be

--- a/inst/unitTests/runit.utils.R
+++ b/inst/unitTests/runit.utils.R
@@ -54,9 +54,48 @@ test.formatLong <- function() {
                   mapInfo = NULL,
                   obsToY = structure(c(1, 0, 0, 0, 1, 0, 0, 0, 1), .Dim = c(3L, 3L))))
 
-  
+  # Compare manual and automatic open point count frame
+  y1 <- matrix(c(
+    0, 2, 3, 2, 0,
+    2, 2, 3, 1, 1,
+    1, 1, 0, 0, 3,
+    0, 0, 0, 0, 0), nrow=4, ncol=5, byrow=TRUE)
 
-    
+  # Site-specific covariates
+  sc1 <- data.frame(x1 = 1:4, x2 = c('A','A','B','B'))
+
+  # Observation-specific covariates
+  oc1 <- list(
+    x3 = matrix(1:5, nrow=4, ncol=5, byrow=TRUE),
+    x4 = matrix(letters[1:5], nrow=4, ncol=5, byrow=TRUE))
+
+  # Primary periods of surveys
+  primaryPeriod1 <- matrix(as.integer(c(
+    1, 2, 5, 7, 8,
+    1, 2, 3, 4, 5,
+    1, 2, 4, 5, 6,
+    1, 3, 5, 6, 7)), nrow=4, ncol=5, byrow=TRUE)
+
+  # Create the unmarkedFrame
+  umf1 <- unmarkedFramePCO(y=y1, siteCovs=sc1, obsCovs=oc1, numPrimary=5,
+                           primaryPeriod=primaryPeriod1)
+
+  test <- data.frame(site = rep(1:4, each = 5),
+                     obsnum = 1:5,
+                     y = as.vector(t(y1)),
+                     x1 = rep(1:4, each = 5),
+                     x2 = rep(c('A','A','B','B'), each = 5),
+                     x3 = 1:5,
+                     x4 = letters[1:5])
+  umf2 <- formatLong(test, type = "unmarkedFramePCO", numPrimary = 5,
+                     primaryPeriod = primaryPeriod1)
+  # formatLong tacks on JulianDate to obsCovs, so ignore this difference
+  checkEquals(umf1@y, umf2@y)
+  checkEquals(umf1@siteCovs, umf2@siteCovs)
+  checkEquals(umf1@obsCovs, umf2@obsCovs[, c("x3", "x4")])
+  checkEquals(umf1@obsToY, umf2@obsToY)
+  checkEquals(umf1@primaryPeriod, umf2@primaryPeriod)
+
 }
 
 

--- a/inst/unitTests/runit.utils.R
+++ b/inst/unitTests/runit.utils.R
@@ -54,6 +54,40 @@ test.formatLong <- function() {
                   mapInfo = NULL,
                   obsToY = structure(c(1, 0, 0, 0, 1, 0, 0, 0, 1), .Dim = c(3L, 3L))))
 
+  # Compare manual and automatic unmarkedPCount frames
+  # Manual creation from help
+  R <- 4 # number of sites
+  J <- 3 # number of visits
+  y <- matrix(c(1,2,0,0,0,0,1,1,1,2,2,1), nrow=R, ncol=J, byrow=TRUE)
+  site.covs <- data.frame(x1=1:4, x2=factor(c('A','B','A','B')))
+  obs.covs <- list(
+    x3 = matrix(c(
+      -1,0,1,
+      -2,0,0,
+      -3,1,0,
+      0,0,0), nrow=R, ncol=J, byrow=TRUE),
+    x4 = matrix(c(
+      'a','b','c',
+      'd','b','a',
+      'a','a','c',
+      'a','b','a'), nrow=R, ncol=J, byrow=TRUE))
+  umf <- unmarkedFramePCount(y=y, siteCovs=site.covs,
+                             obsCovs=obs.covs)          # organize data
+  # Corresponding long data.frame
+  pcdf <- data.frame(site = rep(seq(R), each = J),
+                     occasion = rep(1:J, R),
+                     y = as.vector(t(y)),
+                     x1 = rep(1:4, each = J),
+                     x2 = factor(rep(c('A','B', 'A', 'B'), each = J)),
+                     x3 = as.vector(t(obs.covs$x3)),
+                     x4 = as.vector(t(obs.covs$x4)))
+  umf1 <- formatLong(pcdf, type = "unmarkedFramePCount")
+  # formatLong tacks on JulianDate to obsCovs, so ignore this difference
+  checkEquals(umf@y, umf1@y)
+  checkEquals(umf@siteCovs, umf1@siteCovs)
+  checkEquals(umf@obsCovs, umf1@obsCovs[, c("x3", "x4")])
+  checkEquals(umf@obsToY, umf2@obsToY)
+
   # Compare manual and automatic open point count frame
   y1 <- matrix(c(
     0, 2, 3, 2, 0,

--- a/inst/unitTests/runit.utils.R
+++ b/inst/unitTests/runit.utils.R
@@ -86,7 +86,7 @@ test.formatLong <- function() {
   checkEquals(umf@y, umf1@y)
   checkEquals(umf@siteCovs, umf1@siteCovs)
   checkEquals(umf@obsCovs, umf1@obsCovs[, c("x3", "x4")])
-  checkEquals(umf@obsToY, umf2@obsToY)
+  checkEquals(umf@obsToY, umf1@obsToY)
 
   # Compare manual and automatic open point count frame
   y1 <- matrix(c(

--- a/inst/unitTests/runit.utils.R
+++ b/inst/unitTests/runit.utils.R
@@ -130,6 +130,29 @@ test.formatLong <- function() {
   checkEquals(umf1@obsToY, umf2@obsToY)
   checkEquals(umf1@primaryPeriod, umf2@primaryPeriod)
 
+  # Compare manual and automatic unmarkedFrameDS object
+  # Manual creation from help
+  R <- 4 # number of sites
+  J <- 3 # number of distance classes
+  db <- c(0, 10, 20, 30) # distance break points
+  y <- matrix(c(
+    5,4,3, # 5 detections in 0-10 distance class at this transect
+    0,0,0,
+    2,1,1,
+    1,1,0), nrow=R, ncol=J, byrow=TRUE)
+  site.covs <- data.frame(x1=1:4, x2=factor(c('A','B','A','B')))
+  umf <- unmarkedFrameDS(y=y, siteCovs=site.covs, dist.breaks=db, survey="point",
+                         unitsIn="m")            # organize data
+  # Corresponding long data.frame
+  dsdf <- data.frame(site = rep(seq(R), each = J),
+                     occasion = rep(1:J, R),
+                     y = as.vector(t(y)),
+                     x1 = rep(1:4, each = J),
+                     x2 = factor(rep(c('A','B', 'A', 'B'), each = J)))
+  umf1 <- formatLong(dsdf, type = "unmarkedFrameDS", dist.breaks = db,
+                     survey = "point", unitsIn = "m")
+  checkEquals(umf, umf1)
+
 }
 
 

--- a/man/formatWideLong.Rd
+++ b/man/formatWideLong.Rd
@@ -14,6 +14,11 @@ formatWide(dfin, sep = ".", obsToY, type, ...)
 formatLong(dfin, species = NULL, type, ...)
 }
 \details{
+  Note that not all possible \code{unmarkedFrame}* classes have been tested with these
+  functions. Multinomial data sets (e.g., removal, double-observer, capture-recapture)
+  are almost certainly easier to enter directly to the constructor function and are not
+  supported by \code{formatLong} or \code{formatWide}.
+
   In order for these functions to work, the columns of \code{dfin} need to be in the
   correct order.  \code{formatLong} requires that the columns are in the
   following scheme:

--- a/man/formatWideLong.Rd
+++ b/man/formatWideLong.Rd
@@ -11,7 +11,7 @@ Convert a data.frame between wide and long formats.
 }
 \usage{
 formatWide(dfin, sep = ".", obsToY, type, ...)
-formatLong(dfin, species = NULL, type)
+formatLong(dfin, species = NULL, type, ...)
 }
 \details{
   In order for these functions to work, the columns of \code{dfin} need to be in the
@@ -32,7 +32,7 @@ formatLong(dfin, species = NULL, type)
     \item columns of site-level covariates, each with a relevant name per column.
     \item groups of columns of observation-level covariates, each group
   having the name form \dQuote{someObsCov.1}, \dQuote{someObsCov.2},
-  \ldots, 
+  \ldots,
   \dQuote{someObsCov.J}.
   }
 }
@@ -48,7 +48,7 @@ formatLong(dfin, species = NULL, type)
 }
   \item{species}{Character name of species response column
 }
-  \item{\dots}{Further arguments}
+  \item{\dots}{Further arguments to the unmarkedFrame* constructor functions}
 }
 \value{A data.frame}
 


### PR DESCRIPTION
This PR started simply to allow additional arguments to pass through the `formatLong` function to the specified `unmarkedFrame*` constructor functions. It soon became clear, however, that it would be easier to accomplish this by transitioning from older functions in the `reshape` package (e.g., `melt`, `cast`, and `recast`) to their updated versions in the `reshape2` package (e.g., `melt`, `acast`, `dcast`). The two commits in this PR separate those tasks (edit: four commits; I caught a couple of problems in the DESCRIPTION file).

All relevant unit tests have been updated and pass (excepting an unrelated `parboot` test to be fixed in a follow-up PR), and I've added a test comparing a manually created `unmarkedFramePCO` (from the example in the help file) with the corresponding object created by `formatLong`.

Nonetheless, it's probably worth waiting to [confirm the initial prompt for this PR passes](https://groups.google.com/forum/#!topic/unmarked/L9d1LEpNtXA), and throwing some additional tests for other `unmarkedFrame*` types at the `formatLong`, `formatMult` and `csvToUMF` functions. 