### PR TITLE
Fix getP for distsamp (potentially fixes #83 and maybe #102)

### DIFF
--- a/R/unmarkedFit.R
+++ b/R/unmarkedFit.R
@@ -2630,9 +2630,9 @@ setMethod("getP", "unmarkedFitDS",
                         }},
                 point = {
                     for(j in 1:J) {
-                        cp[i, j] <- u * integrate(grexp, db[j], db[j+1],
+                        cp[i, j] <- integrate(grexp, db[j], db[j+1],
                             rate=rate[i], rel.tol=1e-4)$value *
-                            2 * pi * a[i, j]
+                            2 * pi / a[i, j]
                         }
                     })
                 cp[i,] <- cp[i,] * u[i,]


### PR DESCRIPTION
The likelihood for distsamp exponential/point:

```
                point = {
                    for(j in 1:J) {
                        int <- integrate(grexp, db[j], db[j+1], rate=rate[i],
                            stop.on.error=FALSE)
                        mess <- int$message
                        if(identical(mess, "OK"))
                            cp[i, j] <- int$value * 2*pi / a[i,j]
                        else {
                            cp[i, j] <- NA
                            }
                        }
                    })
                cp[i,] <- cp[i,] * u[i,]

```

In getP the matching chunk looks like this currently:

```
                point = {
                    for(j in 1:J) {
                        cp[i, j] <- u * integrate(grexp, db[j], db[j+1],
                            rate=rate[i], rel.tol=1e-4)$value *
                            2 * pi * a[i, j]
                        }
                    })
cp[i,] <- cp[i,] * u[i,]
```
I am guessing they should match? getP and parboot run now but I haven't confirmed the math.