### PR TITLE
Add C engine for gmultmix

### DIFF
--- a/inst/unitTests/runit.gmultmix.R
+++ b/inst/unitTests/runit.gmultmix.R
@@ -12,28 +12,35 @@ test.gmultmix.fit <- function()
     
     umf <- unmarkedFrameGMM(y = y, siteCovs = siteCovs, obsCovs = obsCovs, 
         yearlySiteCovs = yrSiteCovs, type="removal", numPrimary=2)
-    fm <- gmultmix(~x, ~yr, ~o1 + o2, data = umf, K=23)
-    checkEquals(fm@sitesRemoved, 3)
-    checkEqualsNumeric(coef(fm), 
-        c(2.50638554, 0.06226627, 0.21787839, 6.46029769, -1.51885928, 
-            -0.03409375, 0.43424295), tol = 1e-5)
+    fm_R <- gmultmix(~x, ~yr, ~o1 + o2, data = umf, K=23, engine="R")
+    fm_C <- gmultmix(~x, ~yr, ~o1 + o2, data = umf, K=23, engine="C")
+    
+    checkEquals(fm_R@sitesRemoved, 3)
+    coef_truth <- c(2.50638554, 0.06226627, 0.21787839, 6.46029769, -1.51885928, 
+            -0.03409375, 0.43424295) 
+    checkEqualsNumeric(coef(fm_R), coef_truth, tol = 1e-5) 
+    checkEqualsNumeric(coef(fm_C), coef_truth, tol = 1e-5) 
 
     obsCovs[10,2] <- NA
     umf <- unmarkedFrameGMM(y = y, siteCovs = siteCovs, obsCovs = obsCovs, 
         yearlySiteCovs = yrSiteCovs, type="removal", numPrimary=2)
-    fm <- gmultmix(~x, ~yr, ~o1 + o2, data = umf, K=23)
-    checkEquals(fm@sitesRemoved, 3)
-    checkEqualsNumeric(coef(fm), 
-        c(2.50638554, 0.06226627, 0.21787839, 6.46029769, -1.51885928, 
-            -0.03409375, 0.43424295), tol = 1e-5)
+    fm_R <- gmultmix(~x, ~yr, ~o1 + o2, data = umf, K=23, engine="R")
+    fm_C <- gmultmix(~x, ~yr, ~o1 + o2, data = umf, K=23, engine="C")
+    
+    checkEquals(fm_R@sitesRemoved, 3)
+    checkEqualsNumeric(coef(fm_R), coef_truth, tol = 1e-5) 
+    checkEqualsNumeric(coef(fm_C), coef_truth, tol = 1e-5)
             
     yrSiteCovs[2, 1] <- NA
     umf <- unmarkedFrameGMM(y = y, siteCovs = siteCovs, obsCovs = obsCovs, 
         yearlySiteCovs = yrSiteCovs, type="removal", numPrimary=2)
-    fm <- gmultmix(~x, ~yr, ~o1 + o2, data = umf, K=23)
-    checkEqualsNumeric(coef(fm), 
-        c(1.17280104, 0.37694710, 2.38249795, 2.87354955, -0.83875134, 
-            -0.08446507, 1.88056826), tol = 1e-5)
+    fm_R <- gmultmix(~x, ~yr, ~o1 + o2, data = umf, K=23, engine="R")
+    fm_C <- gmultmix(~x, ~yr, ~o1 + o2, data = umf, K=23, engine="C")
+
+    coef_truth <- c(1.17280104, 0.37694710, 2.38249795, 2.87354955, -0.83875134, 
+            -0.08446507, 1.88056826)
+    checkEqualsNumeric(coef(fm_R), coef_truth, tol = 1e-5)
+    checkEqualsNumeric(coef(fm_C), coef_truth, tol = 1e-5)
 
 
 }

--- a/man/gmultmix.Rd
+++ b/man/gmultmix.Rd
@@ -10,7 +10,7 @@ probability.
 }
 \usage{
 gmultmix(lambdaformula, phiformula, pformula, data,
-mixture = c("P", "NB"), K, starts, method = "BFGS", se = TRUE, ...)
+mixture = c("P", "NB"), K, starts, method = "BFGS", se = TRUE, engine=c("C","R"), ...)
 }
 \arguments{
     \item{lambdaformula}{Righthand side (RHS) formula describing abundance
@@ -24,6 +24,8 @@ mixture = c("P", "NB"), K, starts, method = "BFGS", se = TRUE, ...)
     \item{starts}{Starting values}
     \item{method}{Optimization method used by \code{\link{optim}}}
     \item{se}{Logical. Should standard errors be calculated?}
+    \item{engine}{Either "C" to use fast C++ code or "R" to use native R
+      code during the optimization.}
     \item{\dots}{Additional arguments to optim, such as lower and upper
       bounds}
     }

--- a/src/init.c
+++ b/src/init.c
@@ -11,6 +11,7 @@
 extern SEXP getDetVecs(SEXP y_arr, SEXP mp_arr, SEXP J_i, SEXP tin, SEXP K_) ;
 extern SEXP getSingleDetVec(SEXP y_, SEXP mp_, SEXP K_);
 extern SEXP nll_distsamp( SEXP y_, SEXP lam_, SEXP sig_, SEXP scale_, SEXP a_, SEXP u_, SEXP w_, SEXP db_, SEXP keyfun_, SEXP survey_, SEXP reltol_ );
+extern SEXP nll_gmultmix( SEXP betaR, SEXP mixtureR, SEXP pi_funR, SEXP XlamR, SEXP Xlam_offsetR, SEXP XphiR, SEXP Xphi_offsetR, SEXP XdetR, SEXP Xdet_offsetR, SEXP kR, SEXP lfac_kR, SEXP lfac_kmytR, SEXP kmytR, SEXP yR, SEXP naflagR, SEXP finR, SEXP nPr, SEXP nLPr, SEXP nPPr, SEXP nDPr ) ;
 extern SEXP nll_gpcount( SEXP y_, SEXP Xlam_, SEXP Xphi_, SEXP Xp_, SEXP beta_lam_, SEXP beta_phi_, SEXP beta_p_, SEXP log_alpha_, SEXP Xlam_offset_, SEXP Xphi_offset_, SEXP Xp_offset_, SEXP M_, SEXP mixture_, SEXP numPrimary_ ) ;
 extern SEXP nll_occu( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_psiR, SEXP beta_pR, SEXP ndR, SEXP knownOccR, SEXP navecR, SEXP X_offsetR, SEXP V_offsetR );
 extern SEXP nll_occuPEN( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_psiR, SEXP beta_pR, SEXP ndR, SEXP knownOccR, SEXP navecR, SEXP X_offsetR, SEXP V_offsetR, SEXP penaltyR );
@@ -22,6 +23,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"getDetVecs",      (DL_FUNC) &getDetVecs,       5},
     {"getSingleDetVec", (DL_FUNC) &getSingleDetVec,  3},
     {"nll_distsamp",    (DL_FUNC) &nll_distsamp,    11},
+    {"nll_gmultmix",    (DL_FUNC) &nll_gmultmix,    20},
     {"nll_gpcount",     (DL_FUNC) &nll_gpcount,     14},
     {"nll_occu",        (DL_FUNC) &nll_occu,        10},
     {"nll_occuPEN",     (DL_FUNC) &nll_occuPEN,     11},

--- a/src/nll_gmultmix.cpp
+++ b/src/nll_gmultmix.cpp
@@ -1,0 +1,141 @@
+#include "nll_gmultmix.h"
+
+using namespace Rcpp;
+using namespace arma;
+
+mat inv_logit( mat inp ){
+  return(1 / (1 + exp(-1 * inp)));
+}
+
+vec removalPiFun ( vec p ){
+  int J = p.size();
+  vec pi(J);
+  pi(0) = p(0);
+  for(int j=1; j<J; j++){
+    pi(j) = pi(j-1) / p(j-1) * (1-p(j-1)) * p(j);
+  }
+  return(pi);
+}
+
+vec doublePiFun( vec p ){
+  //p must have 2 columns
+  vec pi(3);
+  pi(0) = p(0) * (1 - p(1));
+  pi(1) = p(1) * (1 - p(0));
+  pi(2) = p(0) * p(1);
+  return(pi);
+}
+
+
+vec piFun( vec p , std::string pi_fun ){
+  if(pi_fun == "removalPiFun"){
+    return(removalPiFun(p));
+  } else if(pi_fun == "doublePiFun"){
+    return(doublePiFun(p));
+  }
+}
+
+
+SEXP nll_gmultmix(SEXP betaR, SEXP mixtureR, SEXP pi_funR, 
+    SEXP XlamR, SEXP Xlam_offsetR, SEXP XphiR, SEXP Xphi_offsetR, SEXP XdetR, 
+    SEXP Xdet_offsetR, SEXP kR, SEXP lfac_kR, SEXP lfac_kmytR, SEXP kmytR, 
+    SEXP yR, SEXP naflagR, SEXP finR, SEXP nPr, SEXP nLPr, SEXP nPPr, SEXP nDPr){
+
+  //Inputs
+  vec beta = as<vec>(betaR);
+  std::string mixture = as<std::string>(mixtureR);
+  std::string pi_fun = as<std::string>(pi_funR);
+
+  mat Xlam = as<mat>(XlamR);
+  vec Xlam_offset = as<vec>(Xlam_offsetR);
+  mat Xphi = as<mat>(XphiR);
+  vec Xphi_offset = as<vec>(Xphi_offsetR);
+  mat Xdet = as<mat>(XdetR);
+  vec Xdet_offset = as<vec>(Xdet_offsetR);
+
+  IntegerVector k(kR);
+  vec lfac_k = as<vec>(lfac_kR);
+  cube lfac_kmyt = as<cube>(lfac_kmytR);
+  cube kmyt = as<cube>(kmytR);
+
+  vec y = as<vec>(yR);
+  vec naflag = as<vec>(naflagR);
+  mat fin = as<mat>(finR);
+
+  int nP = as<int>(nPr);
+  int nLP = as<int>(nLPr);
+  int nPP = as<int>(nPPr);
+  int nDP = as<int>(nDPr);
+
+  int M = Xlam.n_rows;
+  vec lambda = exp( Xlam * beta.subvec(0, (nLP - 1) ) + Xlam_offset );
+  
+  int T = Xphi.n_rows / M;
+  vec phi = ones(M*T);
+  if(T > 1){
+    phi = inv_logit( Xphi * beta.subvec(nLP, (nLP+nPP-1)) + Xphi_offset);
+  }
+  
+  int J = Xdet.n_rows / (M * T);
+  int R = y.size() / (M * T); 
+  vec p = inv_logit( Xdet * beta.subvec((nLP+nPP),(nLP+nPP+nDP-1)) + Xdet_offset);
+  
+  int K = k.size();
+  int t_ind = 0;
+  int y_ind = 0;
+  int p_ind = 0;
+  vec ll(M);
+  for (int m=0; m<M; m++){
+    vec f(K);
+    if(mixture == "P"){
+      f = dpois(k, lambda(m));
+    } else if(mixture == "NB"){
+      f = dnbinom_mu(k, exp(beta(nP-1)), lambda(m));
+    }
+
+    mat A = zeros(K,T);
+    for(int t=0; t<T; t++){
+      int y_stop = y_ind + R - 1;
+      int p_stop = p_ind + J - 1;
+      vec na_sub = naflag.subvec(y_ind, y_stop); 
+
+      if( ! all(na_sub) ){
+
+        vec p1 = lfac_kmyt.subcube(span(m),span(t),span());
+        vec p2 = y.subvec(y_ind, y_stop);
+        vec p3 = piFun( p.subvec(p_ind, p_stop), pi_fun ) * phi(t_ind);
+        //the following line causes a segfault only in R CMD check,
+        //when kmyt contains NA values
+        vec p4 = kmyt.subcube(span(m),span(t),span());
+
+        if( any(na_sub)){
+          uvec ids = find(na_sub!=1);
+          p2 = p2.elem(ids);
+          p3 = p3.elem(ids);
+        }
+
+        double p5 = 1 - sum(p3);
+      
+        A.col(t) = lfac_k - p1 + sum(p2 % log(p3)) + p4 * log(p5);
+      }
+
+      t_ind += 1;
+      y_ind += R;
+      p_ind += J;
+    }
+
+    vec g(K);
+    for (int i=0; i<K; i++){
+      if(!fin(m,i)){
+        f(i) = 0;
+        g(i) = 0;
+      }
+      g(i) = exp(sum(A.row(i)));
+    }
+
+    ll(m) = log(sum(f % g));
+  }
+
+  return(wrap(-sum(ll)));
+
+}

--- a/src/nll_gmultmix.h
+++ b/src/nll_gmultmix.h
@@ -1,0 +1,11 @@
+#ifndef _unmarked_NLL_GMULTMIX_H
+#define _unmarked_NLL_GMULTMIX_H
+
+#include <RcppArmadillo.h>
+
+RcppExport SEXP nll_gmultmix( SEXP betaR, SEXP mixtureR, SEXP pi_funR, 
+    SEXP XlamR, SEXP Xlam_offsetR, SEXP XphiR, SEXP Xphi_offsetR, SEXP XdetR, 
+    SEXP Xdet_offsetR, SEXP kR, SEXP lfac_kR, SEXP lfac_kmytR, SEXP kmytR, 
+    SEXP yR, SEXP naflagR, SEXP finR, SEXP nPr, SEXP nLPr, SEXP nPPr, SEXP nDPr) ;
+
+#endif

--- a/vignettes/cap-recap.Rnw
+++ b/vignettes/cap-recap.Rnw
@@ -721,7 +721,7 @@ function takes 3 formulas for abundance covariates, availability
 covariates, and detection covariates in that order.
 
 <<>>=
-(fm1 <- gmultmix(~woody, ~1, ~time+date, umf.cr))
+(fm1 <- gmultmix(~woody, ~1, ~time+date, umf.cr, engine="R"))
 @
 
 Results from this model are similar to those obtained using the subset


### PR DESCRIPTION
Adds C++ engine for `gmultmix` and makes it the default. In my tests it's about 8-13x faster than the R engine. It works for both Poisson and negative binomial but only for the two built-in piFun options (removal, double). If the user provides a custom piFun it gives a warning and drops back to the R engine. I think you can use an arbitrary R function in C++ via Rcpp but at that point you probably lose most of the speed advantage, so I didn't try to implement that.

I added tests and also had to update the vignette for gmultmix since it uses a custom piFun.

Here's an R script to benchmark the C engine:
[gmultmix_C_example.txt](https://github.com/rbchan/unmarked/files/2897476/gmultmix_C_example.txt)