### PR TITLE
Add C engine for occuRN

### DIFF
--- a/inst/unitTests/runit.occuRN.R
+++ b/inst/unitTests/runit.occuRN.R
@@ -1,0 +1,57 @@
+test.occuRN.fit <- function() {
+  
+  data(birds)
+  woodthrushUMF <- unmarkedFrameOccu(woodthrush.bin)
+
+  # survey occasion-specific detection probabilities
+  fm_C <- occuRN(~ obsNum ~ 1, woodthrushUMF, engine="C")   
+  fm_R <- occuRN(~ obsNum ~ 1, woodthrushUMF, engine="R")
+
+  # check that output matches
+  checkEqualsNumeric(coef(fm_C),coef(fm_R),tol=1e-5)
+
+  # check output is correct
+  checkEqualsNumeric(coef(fm_C),
+    c(0.7921122,-1.8328867,0.4268205,-0.1442194,0.4634105,0.7787513,
+      0.8008794,1.0569827,0.8048578,0.8779660,0.9374874,0.7064848),tol=1e-5)
+
+}
+
+test.occuRN.na <- function() {
+
+  data(birds)
+  woodthrushUMF <- unmarkedFrameOccu(woodthrush.bin)
+  
+  #Remove one observation
+  woodthrushUMF@y[1,1] <- NA
+
+  fm_C <- occuRN(~ obsNum ~ 1, woodthrushUMF, engine="C")   
+  fm_R <- occuRN(~ obsNum ~ 1, woodthrushUMF, engine="R")
+
+  # check that output matches
+  checkEqualsNumeric(coef(fm_C),coef(fm_R),tol=1e-5)
+
+  # check output is correct
+  checkEqualsNumeric(coef(fm_C),
+    c(0.793042, -1.902789, 0.494098, -0.074573, 0.53074, 0.845903,
+    0.867936, 1.123959, 0.871912, 0.944917, 1.004499, 0.773679), tol=1e-5)
+
+  #Remove entire site
+  woodthrush.bin_na <- woodthrush.bin
+  woodthrush.bin_na[1,] <- NA
+  woodthrushUMF <- unmarkedFrameOccu(woodthrush.bin_na)
+
+  fm_C <- occuRN(~ obsNum ~ 1, woodthrushUMF, engine="C")   
+  fm_R <- occuRN(~ obsNum ~ 1, woodthrushUMF, engine="R")
+
+  # check that site was removed
+  checkEqualsNumeric(fm_C@sitesRemoved,1)
+
+  # check that output matches
+  checkEqualsNumeric(coef(fm_C),coef(fm_R),tol=1e-5)
+
+  # check output is correct
+  checkEqualsNumeric(coef(fm_C),
+    c(0.783066, -1.920232, 0.448369, -0.009701, 0.490085, 0.814767,
+    0.837669, 1.097903, 0.842467, 0.916831, 0.976707, 0.740672), tol=1e-5)
+}

--- a/man/occuRN.Rd
+++ b/man/occuRN.Rd
@@ -4,7 +4,7 @@
 
 \title{Fit the occupancy model of Royle and Nichols (2003)}
 
-\usage{occuRN(formula, data, K=25, starts, method="BFGS", se=TRUE, ...)}
+\usage{occuRN(formula, data, K=25, starts, method="BFGS", se=TRUE, engine=c("C","R"),...)}
 
 \arguments{
     \item{formula}{double right-hand side formula describing covariates of
@@ -18,6 +18,8 @@
     \item{method}{Optimization method used by \code{\link{optim}}.}
     \item{se}{logical specifying whether or not to compute standard
       errors.}
+    \item{engine}{Either "C" to use fast C++ code or "R" to use native R
+      code during the optimization.}
     \item{\dots}{Additional arguments to optim, such as lower and upper
       bounds}
   }

--- a/src/init.c
+++ b/src/init.c
@@ -15,6 +15,7 @@ extern SEXP nll_gpcount( SEXP y_, SEXP Xlam_, SEXP Xphi_, SEXP Xp_, SEXP beta_la
 extern SEXP nll_occu( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_psiR, SEXP beta_pR, SEXP ndR, SEXP knownOccR, SEXP navecR, SEXP X_offsetR, SEXP V_offsetR );
 extern SEXP nll_occuPEN( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_psiR, SEXP beta_pR, SEXP ndR, SEXP knownOccR, SEXP navecR, SEXP X_offsetR, SEXP V_offsetR, SEXP penaltyR );
 extern SEXP nll_occuMulti( SEXP fStartR, SEXP fStopR, SEXP dmFr, SEXP dmOccR, SEXP betaR, SEXP dmDetR, SEXP dStartR, SEXP dStopR, SEXP yR, SEXP yStartR, SEXP yStopR, SEXP Iy0r, SEXP zR, SEXP fixed0r);
+extern SEXP nll_occuRN( SEXP betaR, SEXP XlamR, SEXP Xlam_offsetR, SEXP XdetR, SEXP Xdet_offsetR, SEXP KR, SEXP yR, SEXP navecR, SEXP nPr, SEXP nOPr );
 extern SEXP nll_pcount( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_lamR, SEXP beta_pR, SEXP log_alphaR, SEXP X_offsetR, SEXP V_offsetR, SEXP naMatR, SEXP lkR, SEXP mixtureR ) ;
 extern SEXP nll_pcountOpen( SEXP y_, SEXP Xlam_, SEXP Xgam_, SEXP Xom_, SEXP Xp_, SEXP Xiota_, SEXP beta_lam_, SEXP beta_gam_, SEXP beta_om_, SEXP beta_p_, SEXP beta_iota_, SEXP log_alpha_, SEXP Xlam_offset_, SEXP Xgam_offset_, SEXP Xom_offset_, SEXP Xp_offset_, SEXP Xiota_offset_, SEXP ytna_, SEXP yna_, SEXP lk_, SEXP mixture_, SEXP first_, SEXP last_, SEXP M_, SEXP J_, SEXP T_, SEXP delta_, SEXP dynamics_, SEXP fix_, SEXP go_dims_, SEXP immigration_, SEXP I_, SEXP I1_, SEXP Ib_, SEXP Ip_) ;
 
@@ -26,6 +27,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"nll_occu",        (DL_FUNC) &nll_occu,        10},
     {"nll_occuPEN",     (DL_FUNC) &nll_occuPEN,     11},
     {"nll_occuMulti",   (DL_FUNC) &nll_occuMulti,   14},
+    {"nll_occuRN",      (DL_FUNC) &nll_occuRN,      10},
     {"nll_pcount",      (DL_FUNC) &nll_pcount,      11},
     {"nll_pcountOpen",  (DL_FUNC) &nll_pcountOpen,  35},
     {NULL, NULL, 0}

--- a/src/nll_occuRN.cpp
+++ b/src/nll_occuRN.cpp
@@ -1,0 +1,76 @@
+#include "nll_occuRN.h"
+
+using namespace Rcpp;
+using namespace arma;
+
+mat inv_logitRN( mat inp ){
+  return(1 / (1 + exp(-1 * inp)));
+}
+
+
+SEXP nll_occuRN(SEXP betaR, 
+    SEXP XlamR, SEXP Xlam_offsetR, SEXP XdetR, SEXP Xdet_offsetR,  
+    SEXP KR, SEXP yR, SEXP navecR, SEXP nPr, SEXP nOPr){
+
+  //Inputs
+  vec beta = as<vec>(betaR);
+
+  mat Xlam = as<mat>(XlamR);
+  vec Xlam_offset = as<vec>(Xlam_offsetR);
+  mat Xdet = as<mat>(XdetR);
+  vec Xdet_offset = as<vec>(Xdet_offsetR);
+
+  int K = as<int>(KR);
+  
+  vec y = as<vec>(yR);
+  vec navec = as<vec>(navecR);
+
+  int nP = as<int>(nPr);
+  int nOP = as<int>(nOPr);
+
+  int M = Xlam.n_rows;
+  vec lambda = exp( Xlam * beta.subvec(0, (nOP - 1) ) + Xlam_offset );
+  
+  int R = y.size();
+  int J = R / M;
+  vec p = inv_logitRN( Xdet * beta.subvec(nOP,(nP-1)) + Xdet_offset);
+  
+
+  int p_ind = 0;
+  int p_stop = 0;
+
+  mat p_mat(p.size(),(K+1));
+  mat cp_mat = ones(p.size(),(K+1));
+  mat lam_in(M,(K+1));
+  mat cp_in(M,(K+1));
+  vec subcp(J);
+  for (int i=0; i<(K+1); i++){
+
+    p_mat.col(i) = 1 - pow((1 - p),i);
+
+    for (int r=0; r<R; r++){
+      if(!navec(r)){
+        cp_mat(r,i) = pow(p_mat(r,i), y(r)) * pow((1 - p_mat(r,i)),(1-y(r)));
+      }
+    }
+
+    p_ind = 0;
+    for (int m=0; m<M; m++){
+      p_stop = p_ind + J - 1;
+      lam_in(m,i) = R::dpois(i, lambda(m), 0);
+      subcp = cp_mat.submat(span(p_ind,p_stop),span(i));
+      cp_in(m,i) = prod(subcp);
+      p_ind += J;
+    }
+
+  }
+  
+  mat cp_lam = cp_in % lam_in;
+  vec ll(M);
+  for (int m=0; m<M; m++){
+    ll(m) = log(accu(cp_lam.row(m)));
+  }
+
+  return(wrap(-accu(ll)));
+
+}

--- a/src/nll_occuRN.h
+++ b/src/nll_occuRN.h
@@ -1,0 +1,10 @@
+#ifndef _unmarked_NLL_OCCURN_H
+#define _unmarked_NLL_OCCURN_H
+
+#include <RcppArmadillo.h>
+
+RcppExport SEXP nll_occuRN(SEXP betaR, 
+    SEXP XlamR, SEXP Xlam_offsetR, SEXP XdetR, SEXP Xdet_offsetR,  
+    SEXP KR, SEXP yR, SEXP navecR, SEXP nPr, SEXP nOPr) ;
+
+#endif


### PR DESCRIPTION
Adds C++ engine for `occuRN`. It's about 2x faster than the R engine.  I also added tests for `occuRN` (there didn't seem to be any). Finally, this should fix the NA bug noted in issue #77.

R script to benchmark the C++ engine:
[occuRN_C_example.txt](https://github.com/rbchan/unmarked/files/2897540/occuRN_C_example.txt)
  