### PR TITLE
Add C engine for multinomPois

### DIFF
--- a/inst/unitTests/runit.multinomPois.R
+++ b/inst/unitTests/runit.multinomPois.R
@@ -24,19 +24,24 @@ test.removal <- function() {
     o2y[upper.tri(o2y)] <- 1
     checkEquals(obsToY(umf1), o2y)
 
-    m1 <- multinomPois(~1 ~1, umf1)
-    checkEqualsNumeric(coef(m1), c(1.5257743, -0.2328092), tol=1e-5)
+    m1_R <- multinomPois(~1 ~1, umf1, engine="R")
+    m1_C <- multinomPois(~1 ~1, umf1, engine="C")
+    checkEqualsNumeric(coef(m1_R), c(1.5257743, -0.2328092), tol=1e-5)
+    checkEqualsNumeric(coef(m1_R), coef(m1_C), tol=1e-5)
 
-
-    m2 <- multinomPois(~x2 ~1, umf1)
-    checkEqualsNumeric(coef(m2), c(1.9159845, 0.2248897, -0.1808144), tol=1e-5)
-    checkEquals(m2@sitesRemoved, 4:5)
+    m2_R <- multinomPois(~x2 ~1, umf1, engine="R")
+    m2_C <- multinomPois(~x2 ~1, umf1, engine="C")
+    checkEqualsNumeric(coef(m2_R), c(1.9159845, 0.2248897, -0.1808144), tol=1e-5)
+    checkEquals(m2_R@sitesRemoved, 4:5)
+    checkEqualsNumeric(coef(m2_R),coef(m2_C), tol=1e-5)
     
-    m3 <- multinomPois(~x2 ~x1, umf1)
-    checkEqualsNumeric(m3@sitesRemoved, c(1, 4:5))
-    checkEqualsNumeric(coef(m3), 
+    m3_R <- multinomPois(~x2 ~x1, umf1, engine="R")
+    m3_C <- multinomPois(~x2 ~x1, umf1, engine="C")
+    checkEqualsNumeric(m3_R@sitesRemoved, c(1, 4:5))
+    checkEqualsNumeric(coef(m3_R), 
         c(1.9118525, -0.4071202, 8.3569943, 0.3232485), tol=1e-5)    
-    
+    checkEqualsNumeric(coef(m3_R),coef(m3_C), tol=1e-5)
+
     }
     
     
@@ -59,9 +64,11 @@ test.double <- function() {
         
     umf <- unmarkedFrameMPois(y = y, obsCovs = list(x=oc), type="double")    
     
-    m1 <- multinomPois(~1 ~1, umf)
-    checkEqualsNumeric(coef(m1), c(1.3137876, 0.2411609), tol=1e-5)
-    
+    m1_R <- multinomPois(~1 ~1, umf, engine="R")
+    m1_C <- multinomPois(~1 ~1, umf, engine="C")
+    checkEqualsNumeric(coef(m1_R), c(1.3137876, 0.2411609), tol=1e-5)
+    checkEqualsNumeric(coef(m1_R),coef(m1_C))
+
     m2 <- multinomPois(~x ~1, umf, starts=c(1.3, 0, 0.2))
     checkEquals(m2@sitesRemoved, 4:6)    
     }

--- a/man/multinomPois.Rd
+++ b/man/multinomPois.Rd
@@ -5,7 +5,7 @@
 \title{Multinomial-Poisson Mixtures Model}
 
 \usage{multinomPois(formula, data, starts, method = "BFGS",
-   se = TRUE, ...)}
+   se = TRUE, engine=c("C","R"), ...)}
 
 \description{Fit the multinomial-Poisson mixture model to data collected
     using
@@ -42,6 +42,8 @@ Royle, J. A., & Dorazio, R. M. (2006). Hierarchical Models of Animal Abundance a
     \item{method}{Optimization method used by \code{\link{optim}}.}
     \item{se}{logical specifying whether or not to compute standard
       errors.}
+    \item{engine}{Either "C" to use fast C++ code or "R" to use native R
+      code during the optimization.}
     \item{\dots}{Additional arguments to optim, such as lower and upper
       bounds}
 }

--- a/src/init.c
+++ b/src/init.c
@@ -12,6 +12,7 @@ extern SEXP getDetVecs(SEXP y_arr, SEXP mp_arr, SEXP J_i, SEXP tin, SEXP K_) ;
 extern SEXP getSingleDetVec(SEXP y_, SEXP mp_, SEXP K_);
 extern SEXP nll_distsamp( SEXP y_, SEXP lam_, SEXP sig_, SEXP scale_, SEXP a_, SEXP u_, SEXP w_, SEXP db_, SEXP keyfun_, SEXP survey_, SEXP reltol_ );
 extern SEXP nll_gpcount( SEXP y_, SEXP Xlam_, SEXP Xphi_, SEXP Xp_, SEXP beta_lam_, SEXP beta_phi_, SEXP beta_p_, SEXP log_alpha_, SEXP Xlam_offset_, SEXP Xphi_offset_, SEXP Xp_offset_, SEXP M_, SEXP mixture_, SEXP numPrimary_ ) ;
+extern SEXP nll_multinomPois( SEXP betaR, SEXP pi_funR, SEXP XlamR, SEXP Xlam_offsetR, SEXP XdetR, SEXP Xdet_offsetR, SEXP yR, SEXP navecR, SEXP nPr, SEXP nAPr ) ;
 extern SEXP nll_occu( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_psiR, SEXP beta_pR, SEXP ndR, SEXP knownOccR, SEXP navecR, SEXP X_offsetR, SEXP V_offsetR );
 extern SEXP nll_occuPEN( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_psiR, SEXP beta_pR, SEXP ndR, SEXP knownOccR, SEXP navecR, SEXP X_offsetR, SEXP V_offsetR, SEXP penaltyR );
 extern SEXP nll_occuMulti( SEXP fStartR, SEXP fStopR, SEXP dmFr, SEXP dmOccR, SEXP betaR, SEXP dmDetR, SEXP dStartR, SEXP dStopR, SEXP yR, SEXP yStartR, SEXP yStopR, SEXP Iy0r, SEXP zR, SEXP fixed0r);
@@ -23,6 +24,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"getSingleDetVec", (DL_FUNC) &getSingleDetVec,  3},
     {"nll_distsamp",    (DL_FUNC) &nll_distsamp,    11},
     {"nll_gpcount",     (DL_FUNC) &nll_gpcount,     14},
+    {"nll_multinomPois",(DL_FUNC) &nll_multinomPois,10},
     {"nll_occu",        (DL_FUNC) &nll_occu,        10},
     {"nll_occuPEN",     (DL_FUNC) &nll_occuPEN,     11},
     {"nll_occuMulti",   (DL_FUNC) &nll_occuMulti,   14},

--- a/src/nll_multinomPois.cpp
+++ b/src/nll_multinomPois.cpp
@@ -1,0 +1,92 @@
+#include "nll_multinomPois.h"
+
+using namespace Rcpp;
+using namespace arma;
+
+mat inv_logit_( mat inp ){
+  return(1 / (1 + exp(-1 * inp)));
+}
+
+vec removalPiFun_( vec p ){
+  int J = p.size();
+  vec pi(J);
+  pi(0) = p(0);
+  for(int j=1; j<J; j++){
+    pi(j) = pi(j-1) / p(j-1) * (1-p(j-1)) * p(j);
+  }
+  return(pi);
+}
+
+vec doublePiFun_( vec p ){
+  //p must have 2 columns
+  vec pi(3);
+  pi(0) = p(0) * (1 - p(1));
+  pi(1) = p(1) * (1 - p(0));
+  pi(2) = p(0) * p(1);
+  return(pi);
+}
+
+
+vec piFun_( vec p , std::string pi_fun ){
+  if(pi_fun == "removalPiFun"){
+    return(removalPiFun_(p));
+  } else if(pi_fun == "doublePiFun"){
+    return(doublePiFun_(p));
+  }
+}
+
+
+SEXP nll_multinomPois(SEXP betaR, SEXP pi_funR, 
+    SEXP XlamR, SEXP Xlam_offsetR, SEXP XdetR, SEXP Xdet_offsetR,  
+    SEXP yR, SEXP navecR, SEXP nPr, SEXP nAPr){
+
+  //Inputs
+  vec beta = as<vec>(betaR);
+  std::string pi_fun = as<std::string>(pi_funR);
+
+  mat Xlam = as<mat>(XlamR);
+  vec Xlam_offset = as<vec>(Xlam_offsetR);
+  mat Xdet = as<mat>(XdetR);
+  vec Xdet_offset = as<vec>(Xdet_offsetR);
+
+  vec y = as<vec>(yR);
+  vec navec = as<vec>(navecR);
+
+  int nP = as<int>(nPr);
+  int nAP = as<int>(nAPr);
+
+  int M = Xlam.n_rows;
+  vec lambda = exp( Xlam * beta.subvec(0, (nAP - 1) ) + Xlam_offset );
+  
+  int J = Xdet.n_rows / M;
+  int R = y.size() / M; 
+  vec p = inv_logit_( Xdet * beta.subvec(nAP,(nP-1)) + Xdet_offset);
+  
+  int y_ind = 0;
+  int p_ind = 0;
+
+  mat ll = zeros(M,R);
+  for (int m=0; m<M; m++){
+
+    int y_stop = y_ind + R - 1;
+    int p_stop = p_ind + J - 1;
+
+    vec na_sub = navec.subvec(y_ind, y_stop); 
+    if( ! all(na_sub) ){
+
+      vec pi_lam = piFun_( p.subvec(p_ind, p_stop), pi_fun ) * lambda(m);  
+      
+      for (int r=0; r<R; r++){
+        if( ! na_sub(r) ){
+           ll(m,r) = R::dpois(y(y_ind+r), pi_lam(r), 1);
+        }
+      }
+    }
+
+      y_ind += R;
+      p_ind += J;
+  }
+
+  return(wrap(-accu(ll)));
+
+}

--- a/src/nll_multinomPois.h
+++ b/src/nll_multinomPois.h
@@ -1,0 +1,10 @@
+#ifndef _unmarked_NLL_MULTINOMPOIS_H
+#define _unmarked_NLL_MULTINOMPOIS_H
+
+#include <RcppArmadillo.h>
+
+RcppExport SEXP nll_multinomPois(SEXP betaR, SEXP pi_funR, 
+    SEXP XlamR, SEXP Xlam_offsetR, SEXP XdetR, SEXP Xdet_offsetR,  
+    SEXP yR, SEXP navecR, SEXP nPr, SEXP nAPr) ;
+
+#endif

--- a/vignettes/cap-recap.Rnw
+++ b/vignettes/cap-recap.Rnw
@@ -374,9 +374,9 @@ continuous covariate effect on $p$.
 
 
 <<>>=
-M0 <- multinomPois(~1 ~1, umf.cr1)
-Mt <- multinomPois(~interval-1 ~1, umf.cr1)
-Mx <- multinomPois(~time.1 ~1, umf.cr1)
+M0 <- multinomPois(~1 ~1, umf.cr1, engine="R")
+Mt <- multinomPois(~interval-1 ~1, umf.cr1, engine="R")
+Mx <- multinomPois(~time.1 ~1, umf.cr1, engine="R")
 @
 
 The first two models can be fit in other software programs. What is
@@ -386,7 +386,7 @@ treats abundance as
 a function of the percent cover of woody vegetation.
 
 <<>>=
-(M0.woody <- multinomPois(~1 ~woody, umf.cr1))
+(M0.woody <- multinomPois(~1 ~woody, umf.cr1, engine="R"))
 @
 
 
@@ -482,13 +482,13 @@ umf.cr1Mb <- unmarkedFrameMPois(y=alfl.H1,
     siteCovs=alfl.covs[,c("woody", "struct", "time.1")],
     obsCovs=list(behavior=behavior),
     obsToY=o2y, piFun="crPiFun.Mb")
-M0 <- multinomPois(~1 ~1, umf.cr1Mb)
+M0 <- multinomPois(~1 ~1, umf.cr1Mb, engine="R")
 @
 
 \newpage
 
 <<>>=
-(Mb <- multinomPois(~behavior-1 ~1, umf.cr1Mb))
+(Mb <- multinomPois(~behavior-1 ~1, umf.cr1Mb, engine="R"))
 @
 AIC gives us no reason to favor model $M_b$ over model $M_0$. This is
 perhaps not too surprising given that the alder


### PR DESCRIPTION
Adds C++ engine for `multinomPois` and makes it the default. It's not a lot faster (maybe 30%), but `multinomPois` was already pretty fast (at least for the example datasets). As with `gmultmix` it only supports double/removal piFuns -  if the user provides a custom piFun it gives a warning and drops back to the R engine. I added tests and also had to update the cap-recap vignette since it uses a custom piFun for `multinomPois`.

Here's an R script to benchmark the C engine:
[multinomPois_C_example.txt](https://github.com/rbchan/unmarked/files/2897560/multinomPois_C_example.txt)
