### PR TITLE
Fix umf subsetting with list when there are no obsCovs (for nonparboot)

### DIFF
--- a/R/unmarkedFrame.R
+++ b/R/unmarkedFrame.R
@@ -914,7 +914,7 @@ setMethod("[", c("unmarkedFrame","list", "missing", "missing"),
     if (m != length(i)) stop("list length must be same as number of sites.")
     siteCovs <- siteCovs(x)
     y <- cbind(.site=1:m, getY(x))
-    obsCovs <- cbind(.site=rep(1:m, each=R), obsCovs(x))
+    obsCovs <- as.data.frame(cbind(.site=rep(1:m, each=R), obsCovs(x)))
 
     obsCovs <- ddply(obsCovs, ~.site, function(df) {
         site <- df$.site[1]
@@ -933,8 +933,10 @@ setMethod("[", c("unmarkedFrame","list", "missing", "missing"),
         obs <- c(obs, rep(NA, R-length(obs)))
         row[obs]
         })
-
-    obsCovs(x) <- obsCovs
+    
+    if(!is.null(obsCovs(x))){
+      obsCovs(x) <- obsCovs
+    }
     x@y <- t(y)
     x
 })

--- a/inst/unitTests/runit.nonparboot.R
+++ b/inst/unitTests/runit.nonparboot.R
@@ -153,3 +153,15 @@ test.nonparboot.colext <- function() {
 
 
 }
+
+test.nonparboot.noObsCovs <- function() {
+
+    data(frogs)
+    #No obs covs
+    pferUMF <- unmarkedFrameOccu(pfer.bin)
+    set.seed(123)
+    fm <- occu(~ 1 ~ 1, pferUMF)
+    npb <- nonparboot(fm,B=4)
+    checkEqualsNumeric(SE(npb), c(29.4412950, 0.1633507), tol=1e-5)
+
+}


### PR DESCRIPTION
Fixes issue #92 and adds relevant test.