### PR TITLE
Dependent double observer sampling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Collate: 'classes.R' 'unmarkedEstimate.R' 'mapInfo.R' 'unmarkedFrame.R'
     'multinomPois.R' 'occu.R' 'occuRN.R' 'occuMulti.R' 'pcount.R' 'gmultmix.R'
     'pcountOpen.R' 'gdistsamp.R' 'unmarkedFitList.R' 'unmarkedLinComb.R'
     'ranef.R' 'boot.R' 'occuFP.R' 'gpcount.R' 'occuPEN.R' 'pcount.spHDS.R'
-    'unmarkedCrossVal.R'
+    'unmarkedCrossVal.R' 'piFun.R'
 LinkingTo: Rcpp, RcppArmadillo 
 SystemRequirements: GNU make
 URL: http://groups.google.com/group/unmarked,

--- a/R/gmultmix.R
+++ b/R/gmultmix.R
@@ -144,8 +144,8 @@ if(engine=="R"){
   kmytC[which(is.na(kmyt))] <- 0
   nll <- nll_C
 
-  if(!piFun%in%c('doublePiFun','removalPiFun')){
-    warning("C engine only supports double and removal pi functions. Falling back to R engine.")
+  if(!piFun%in%c('doublePiFun','removalPiFun','depDoublePiFun')){
+    warning("Custom pi functions are not supported by C engine. Using R engine instead.")
     nll <- nll_R
   }
 

--- a/R/multinomPois.R
+++ b/R/multinomPois.R
@@ -1,37 +1,3 @@
-
-## Take an M x J matrix of detection probabilities and return a matrix
-## of M x J observation probs
-# Compute the cell probabilities for the observation classes
-# in removal sampling.
-#
-# Both p and the returned matrix are M x J for M sites and J sampling occasions.
-
-removalPiFun <- function(p){
-  M <- nrow(p)
-  J <- ncol(p)
-  pi <- matrix(NA, M, J)
-  pi[,1] <- p[,1]
-  for(i in seq(from = 2, length = J - 1)) {
-	  pi[, i] <- pi[,i-1] / p[,i-1] * (1-p[,i-1]) * p[,i]
-  }
-  return(pi)
-}
-
-# p is an M x 2 matrix of detection probabilities (site x observer).
-# returns an M x 3 matrix of row=(1 not 2, 2 not 1, 1 and 2).
-# Compute the cell probabilities for the observation classes
-# in double observer sampling.
-
-doublePiFun <- function(p){
-  M <- nrow(p)
-  pi <- matrix(NA, M, 3)
-  pi[,1] <- p[,1] * (1 - p[,2])
-  pi[,2] <- p[,2] * (1 - p[,1])
-  pi[,3] <- p[,1] * p[,2]
-  return(pi)
-}
-
-
 # Fit the multinomial-Poisson abundance mixture model.
 
 multinomPois <- function(formula, data, starts, method = "BFGS",

--- a/R/multinomPois.R
+++ b/R/multinomPois.R
@@ -55,8 +55,8 @@ multinomPois <- function(formula, data, starts, method = "BFGS",
       yC <- as.numeric(t(y))
       navecC <- is.na(yC)
       nll <- nll_C
-      if(!piFun%in%c('doublePiFun','removalPiFun')){
-        warning("C engine only supports double and removal pi functions. Falling back to R engine.")
+      if(!piFun%in%c('doublePiFun','removalPiFun','depDoublePiFun')){
+        warning("Custom pi functions are not supported by C engine. Using R engine instead.")
         nll <- nll_R
       }
     }

--- a/R/piFun.R
+++ b/R/piFun.R
@@ -1,0 +1,44 @@
+## Take an M x J matrix of detection probabilities and return a matrix
+## of M x J observation probs
+# Compute the cell probabilities for the observation classes
+# in removal sampling.
+#
+# Both p and the returned matrix are M x J for M sites and J sampling occasions.
+
+removalPiFun <- function(p){
+  M <- nrow(p)
+  J <- ncol(p)
+  pi <- matrix(NA, M, J)
+  pi[,1] <- p[,1]
+  for(i in seq(from = 2, length = J - 1)) {
+	  pi[, i] <- pi[,i-1] / p[,i-1] * (1-p[,i-1]) * p[,i]
+  }
+  return(pi)
+}
+
+# p is an M x 2 matrix of detection probabilities (site x observer).
+# returns an M x 3 matrix of row=(1 not 2, 2 not 1, 1 and 2).
+# Compute the cell probabilities for the observation classes
+# in double observer sampling.
+
+doublePiFun <- function(p){
+  M <- nrow(p)
+  pi <- matrix(NA, M, 3)
+  pi[,1] <- p[,1] * (1 - p[,2])
+  pi[,2] <- p[,2] * (1 - p[,1])
+  pi[,3] <- p[,1] * p[,2]
+  return(pi)
+}
+
+# p is an M x 2 matrix of detection probabilities (site x observer).
+# returns an M x 2 matrix of row=(1, 2 not 1).
+# Compute the cell probabilities for the observation classes
+# in double observer sampling.
+
+depDoublePiFun <- function(p){
+  M <- nrow(p) 
+  pi <- matrix(NA, M, 2) 
+  pi[,1] <- p[,1] 
+  pi[,2] <- p[,2]*(1-p[,1]) 
+  return(pi) 
+}

--- a/R/unmarkedFrame.R
+++ b/R/unmarkedFrame.R
@@ -267,7 +267,11 @@ unmarkedFrameMPois <- function(y, siteCovs = NULL, obsCovs = NULL, type,
                 #obsToY <- matrix(c(1, 0, 0, 1, 1, 1), 2, 3)
                 obsToY <- matrix(1, 2, 3)
                 piFun <- "doublePiFun"
-                })
+                },  
+            depDouble = {
+              obsToY <- matrix(1, 2, 2)
+              piFun <- "depDoublePiFun"
+              })
     } else {
         if(missing(obsToY))
             stop("obsToY is required for multinomial-Poisson data with no specified type.")

--- a/R/unmarkedFrame.R
+++ b/R/unmarkedFrame.R
@@ -319,8 +319,8 @@ unmarkedFrameGMM <- function(y, siteCovs = NULL, obsCovs = NULL, numPrimary,
 {
     J <- ncol(y) / numPrimary
     if(!missing(type)) {
-      if(!type %in% c("removal", "double"))
-        stop("if specifying type, it should either be 'removal' or 'double'")
+      if(!type %in% c("removal", "double", "depDouble"))
+        stop("if specifying type, it should either be 'removal', 'double', or 'depDouble'")
       switch(type,
         removal = {
           obsToY <- diag(J)
@@ -332,6 +332,11 @@ unmarkedFrameGMM <- function(y, siteCovs = NULL, obsCovs = NULL, numPrimary,
           obsToY <- matrix(1, 2, 3)
           obsToY <- kronecker(diag(numPrimary), obsToY)
           piFun <- "doublePiFun"
+          },
+        depDouble = {
+          obsToY <- matrix(1, 2, 2) 
+          obsToY <- kronecker(diag(numPrimary), obsToY) 
+          piFun <- "depDoublePiFun"
           })
     } else {
        ### 2/4/2019 ... cat("this is a test message",fill=TRUE)

--- a/inst/unitTests/runit.pifun.R
+++ b/inst/unitTests/runit.pifun.R
@@ -1,0 +1,123 @@
+test.pifun.gmultmix <- function(){
+
+    set.seed(123)
+    y <- matrix(0:3, 5, 4)
+    siteCovs <- data.frame(x = c(0,2,3,4,1))
+    siteCovs[3,1] <- NA
+    obsCovs <- data.frame(o1 = 1:20, o2 = exp(-5:4)/20)
+    yrSiteCovs <- data.frame(yr=factor(rep(1:2, 5)))
+
+    #bad type
+    checkException(unmarkedFrameGMM(y = y, siteCovs = siteCovs, 
+                                           obsCovs = obsCovs, 
+                                           yearlySiteCovs = yrSiteCovs, 
+                                           type="fake", numPrimary=2))
+    
+    #type = "removal"
+    umf <- unmarkedFrameGMM(y = y, siteCovs = siteCovs, obsCovs = obsCovs, 
+        yearlySiteCovs = yrSiteCovs, type="removal", numPrimary=2)
+    fm_R <- gmultmix(~x, ~yr, ~o1 + o2, data = umf, K=23, engine="R")
+    fm_C <- gmultmix(~x, ~yr, ~o1 + o2, data = umf, K=23, engine="C")
+    coef_truth <- c(2.50638554, 0.06226627, 0.21787839, 6.46029769, -1.51885928, 
+            -0.03409375, 0.43424295) 
+    checkEqualsNumeric(coef(fm_R), coef_truth, tol = 1e-5) 
+    checkEqualsNumeric(coef(fm_C), coef_truth, tol = 1e-5)
+ 
+    #type = "double"
+    set.seed(123)
+    y <- matrix(0:3, 5, 6)
+    siteCovs <- data.frame(x = c(0,2,3,4,1))
+    siteCovs[3,1] <- NA
+    obsCovs <- data.frame(o1 = 1:20, o2 = exp(-5:4)/30)
+    yrSiteCovs <- data.frame(yr=factor(rep(1:2, 5)))
+    
+    umf <- unmarkedFrameGMM(y = y, siteCovs = siteCovs, obsCovs = obsCovs, 
+        yearlySiteCovs = yrSiteCovs, type="double", numPrimary=2)
+    fm_R <- gmultmix(~x, ~yr, ~o1 + o2, data = umf, K=23, engine="R")
+    fm_C <- gmultmix(~x, ~yr, ~o1 + o2, data = umf, K=23, engine="C")
+    coef_truth <- c(2.42178997506, 0.0790163156156549, -0.483051837753635, 
+                    0.0869555282843506,0.748689310997745, -0.0458486142792914, 
+                    -0.374467809850705)
+    checkEqualsNumeric(coef(fm_R), coef_truth, tol = 1e-5) 
+    checkEqualsNumeric(coef(fm_C), coef_truth, tol = 1e-5)
+
+    #type = "depDouble"
+    set.seed(123)
+    y <- matrix(0:3, 5, 4)
+    siteCovs <- data.frame(x = c(0,2,3,4,1))
+    siteCovs[3,1] <- NA
+    obsCovs <- data.frame(o1 = 1:20, o2 = exp(-5:4)/20)
+    yrSiteCovs <- data.frame(yr=factor(rep(1:2, 5)))
+    
+    umf <- unmarkedFrameGMM(y = y, siteCovs = siteCovs, obsCovs = obsCovs, 
+        yearlySiteCovs = yrSiteCovs, type="depDouble", numPrimary=2)
+    
+    fm_R <- gmultmix(~x, ~yr, ~o1 + o2, data = umf, K=23, engine="R")
+    fm_C <- gmultmix(~x, ~yr, ~o1 + o2, data = umf, K=23, engine="C")
+    coef_truth <- c(2.50638554076642, 0.0622662713385639, 0.217878385786452, 
+                    6.46029769667278,-1.51885927831977, -0.0340937462852327, 
+                    0.434242947016337) 
+    checkEqualsNumeric(coef(fm_R), coef_truth, tol = 1e-5) 
+    checkEqualsNumeric(coef(fm_C), coef_truth, tol = 1e-5)
+}
+
+test.pifun.multinomPois <- function(){
+
+     nSites <- 50
+     lambda <- 10
+     p1 <- 0.5
+     p2 <- 0.3
+     cp <- c(p1*(1-p2), p2*(1-p1), p1*p2)
+     set.seed(9023)
+     N <- rpois(nSites, lambda)
+     y <- matrix(NA, nSites, 3)
+     for(i in 1:nSites) {
+       y[i,] <- rmultinom(1, N[i], c(cp, 1-sum(cp)))[1:3]
+     }
+     
+     # incorrect type
+     observer <- matrix(c('A','B'), nSites, 2, byrow=TRUE)
+     #TODO: This should return a more informative error than it does
+     checkException(unmarkedFrameMPois(y=y, obsCovs=list(observer=observer),
+         type="fake"))
+    
+     #Type "double"
+     umf <- unmarkedFrameMPois(y=y, obsCovs=list(observer=observer),
+         type="double")
+     fm_R <- multinomPois(~observer-1 ~1, umf, engine="R") 
+     fm_C <- multinomPois(~observer-1 ~1, umf, engine="C")
+     coef_truth <- c(2.2586622, 0.1739752, -0.5685933)
+     checkEqualsNumeric(coef(fm_R), coef_truth, tol = 1e-5)
+     checkEqualsNumeric(coef(fm_C), coef_truth, tol = 1e-5)
+      
+     #Type "depDouble" 
+     nSites <- 50
+     lambda <- 10
+     p1 <- 0.5
+     p2 <- 0.3
+     cp <- c(p1, p2*(1-p1))
+     set.seed(9023)
+     N <- rpois(nSites, lambda)
+     y <- matrix(NA, nSites, 2)
+     for(i in 1:nSites) {
+       y[i,] <- rmultinom(1, N[i], c(cp, 1-sum(cp)))[1:2]
+     } 
+     # Fit model
+     observer <- matrix(c('A','B'), nSites, 2, byrow=TRUE)
+     umf <- unmarkedFrameMPois(y=y, obsCovs=list(observer=observer),
+         type="depDouble")
+     fm_R <- multinomPois(~observer-1 ~1, umf, engine="R")
+     fm_C <- multinomPois(~observer-1 ~1, umf, engine="C")
+     coef_truth <- c(2.0416086, 0.7430343, 0.4564236)
+     checkEqualsNumeric(coef(fm_R), coef_truth, tol = 1e-5)
+     checkEqualsNumeric(coef(fm_C), coef_truth, tol = 1e-5)
+
+     #Type "removal"
+     umf <- unmarkedFrameMPois(y=y, obsCovs=list(observer=observer),
+         type="removal")
+     fm_R <- multinomPois(~observer-1 ~1, umf, engine="R")
+     fm_C <- multinomPois(~observer-1 ~1, umf, engine="C")
+     coef_truth <- c(2.0416086, 0.7430343, 0.4564236)
+     checkEqualsNumeric(coef(fm_R), coef_truth, tol = 1e-5)
+     checkEqualsNumeric(coef(fm_C), coef_truth, tol = 1e-5)
+}

--- a/man/unmarkedFrameMPois.Rd
+++ b/man/unmarkedFrameMPois.Rd
@@ -21,8 +21,9 @@
     \item{obsCovs}{Either a named list of RxJ \code{\link{data.frame}}s or 
         a \code{data.frame} with RxJ rows and one column per covariate. 
         For the latter format, the covariates should be in site-major order.}
-    \item{type}{Either "removal" or "double" for removal sampling or double 
-        observer sampling. If this argument not specified, the user must
+    \item{type}{Either "removal" for removal sampling, "double" for standard 
+        double observer sampling, or "depDouble" for dependent double observer 
+        sampling. If this argument not specified, the user must
         provide an \code{obsToY} matrix. See details.}
     \item{obsToY}{A matrix describing the relationship between \code{obsCovs} 
         and \code{y}. This is necessary because under some sampling designs 
@@ -31,11 +32,11 @@
         there are 3 observations (seen only by observer A, detected only by 
         observer B, and detected by both), but each observation-level covariate
         can only have 2 columns, one for each observer. This matrix is created 
-        automatically if \code{type} is either "removal" or "double". } 
+        automatically if \code{type} is specified. } 
     \item{mapInfo}{Currently ignored}
     \item{piFun}{Function used to compute the multinomial cell probabilities 
         from a matrix of detection probabilities. This is created automatically
-        if \code{type} is either "removal" or "double".}}
+        if \code{type} is specified.}}
 
 \details{
     unmarkedFrameMPois is the S4 class that holds data to be passed 

--- a/man/unmarkedMultFrame.Rd
+++ b/man/unmarkedMultFrame.Rd
@@ -56,9 +56,9 @@ the survey design used that resulted in multinomial outcomes. For
 unmarkedFrameGMM and constant-interval removal sampling, you can set
 type="removal" and ignore
 the arguments obsToY and piFun. Similarly, for double-observer sampling,
-setting type="double" will automatically create an appropiate obsToY matrix and
-\code{\link{piFuns}}. For all other situations, the type argument of
-unmarkedFrameGMM should be
+setting type="double" or type="depDouble" will automatically create an appropiate 
+obsToY matrix and \code{\link{piFuns}}. For all other situations, the type 
+argument of unmarkedFrameGMM should be
 ignored and the obsToY and piFun arguments must be specified. piFun must be a
 function that converts an MxJ matrix of detection probabilities into an MxJ
 matrix of multinomial cell probabilities. obsToY is a matrix describing how
@@ -85,9 +85,10 @@ unmarkedMultFrame using the
         multiseason model).}
     \item{yearlySiteCovs}{Data frame containing covariates at the
         site-year level.}
-    \item{type}{Either "removal" or "double" for constant-interval removal
-        sampling or double observer sampling. This should be not be specified
-        for other types of survey designs.}
+    \item{type}{Set to "removal" for constant-interval removal
+        sampling, "double" for standard double observer sampling, or 
+        "depDouble" for dependent double observer sampling. 
+        This should be not be specified for other types of survey designs.}
     \item{obsToY}{A matrix specifying relationship between observation-level
         covariates and response matrix}
     \item{piFun}{A function converting an MxJ matrix of detection probabilities

--- a/src/nll_gmultmix.cpp
+++ b/src/nll_gmultmix.cpp
@@ -135,11 +135,11 @@ SEXP nll_gmultmix(SEXP betaR, SEXP mixtureR, SEXP pi_funR,
 
     vec g(K);
     for (int i=0; i<K; i++){
+      g(i) = exp(sum(A.row(i)));
       if(!fin(m,i)){
         f(i) = 0;
         g(i) = 0;
       }
-      g(i) = exp(sum(A.row(i)));
     }
 
     ll(m) = log(sum(f % g));

--- a/src/nll_gmultmix.cpp
+++ b/src/nll_gmultmix.cpp
@@ -1,47 +1,11 @@
 #include "nll_gmultmix.h"
+#include "pifun.h"
 
 using namespace Rcpp;
 using namespace arma;
 
 mat inv_logit( mat inp ){
   return(1 / (1 + exp(-1 * inp)));
-}
-
-vec removalPiFun ( vec p ){
-  int J = p.size();
-  vec pi(J);
-  pi(0) = p(0);
-  for(int j=1; j<J; j++){
-    pi(j) = pi(j-1) / p(j-1) * (1-p(j-1)) * p(j);
-  }
-  return(pi);
-}
-
-vec doublePiFun( vec p ){
-  //p must have 2 columns
-  vec pi(3);
-  pi(0) = p(0) * (1 - p(1));
-  pi(1) = p(1) * (1 - p(0));
-  pi(2) = p(0) * p(1);
-  return(pi);
-}
-
-vec depDoublePiFun( vec p ){
-  //p must have 2 columns
-  vec pi(2);
-  pi(0) = p(0);
-  pi(1) = p(1) * (1 - p(0));
-  return(pi);
-}
-
-vec piFun( vec p , std::string pi_fun ){
-  if(pi_fun == "removalPiFun"){
-    return(removalPiFun(p));
-  } else if(pi_fun == "doublePiFun"){
-    return(doublePiFun(p));
-  } else if(pi_fun == "depDoublePiFun"){
-    return(depDoublePiFun(p));
-  }
 }
 
 

--- a/src/nll_gmultmix.cpp
+++ b/src/nll_gmultmix.cpp
@@ -26,12 +26,21 @@ vec doublePiFun( vec p ){
   return(pi);
 }
 
+vec depDoublePiFun( vec p ){
+  //p must have 2 columns
+  vec pi(2);
+  pi(0) = p(0);
+  pi(1) = p(1) * (1 - p(0));
+  return(pi);
+}
 
 vec piFun( vec p , std::string pi_fun ){
   if(pi_fun == "removalPiFun"){
     return(removalPiFun(p));
   } else if(pi_fun == "doublePiFun"){
     return(doublePiFun(p));
+  } else if(pi_fun == "depDoublePiFun"){
+    return(depDoublePiFun(p));
   }
 }
 

--- a/src/nll_multinomPois.cpp
+++ b/src/nll_multinomPois.cpp
@@ -1,4 +1,5 @@
 #include "nll_multinomPois.h"
+#include "pifun.h"
 
 using namespace Rcpp;
 using namespace arma;
@@ -6,35 +7,6 @@ using namespace arma;
 mat inv_logit_( mat inp ){
   return(1 / (1 + exp(-1 * inp)));
 }
-
-vec removalPiFun_( vec p ){
-  int J = p.size();
-  vec pi(J);
-  pi(0) = p(0);
-  for(int j=1; j<J; j++){
-    pi(j) = pi(j-1) / p(j-1) * (1-p(j-1)) * p(j);
-  }
-  return(pi);
-}
-
-vec doublePiFun_( vec p ){
-  //p must have 2 columns
-  vec pi(3);
-  pi(0) = p(0) * (1 - p(1));
-  pi(1) = p(1) * (1 - p(0));
-  pi(2) = p(0) * p(1);
-  return(pi);
-}
-
-
-vec piFun_( vec p , std::string pi_fun ){
-  if(pi_fun == "removalPiFun"){
-    return(removalPiFun_(p));
-  } else if(pi_fun == "doublePiFun"){
-    return(doublePiFun_(p));
-  }
-}
-
 
 SEXP nll_multinomPois(SEXP betaR, SEXP pi_funR, 
     SEXP XlamR, SEXP Xlam_offsetR, SEXP XdetR, SEXP Xdet_offsetR,  
@@ -74,7 +46,7 @@ SEXP nll_multinomPois(SEXP betaR, SEXP pi_funR,
     vec na_sub = navec.subvec(y_ind, y_stop); 
     if( ! all(na_sub) ){
 
-      vec pi_lam = piFun_( p.subvec(p_ind, p_stop), pi_fun ) * lambda(m);  
+      vec pi_lam = piFun( p.subvec(p_ind, p_stop), pi_fun ) * lambda(m);  
       
       for (int r=0; r<R; r++){
         if( ! na_sub(r) ){

--- a/src/pifun.cpp
+++ b/src/pifun.cpp
@@ -1,0 +1,41 @@
+#include <RcppArmadillo.h>
+
+using namespace Rcpp;
+using namespace arma;
+
+vec removalPiFun ( vec p ){
+  int J = p.size();
+  vec pi(J);
+  pi(0) = p(0);
+  for(int j=1; j<J; j++){
+    pi(j) = pi(j-1) / p(j-1) * (1-p(j-1)) * p(j);
+  }
+  return(pi);
+}
+
+vec doublePiFun( vec p ){
+  //p must have 2 columns
+  vec pi(3);
+  pi(0) = p(0) * (1 - p(1));
+  pi(1) = p(1) * (1 - p(0));
+  pi(2) = p(0) * p(1);
+  return(pi);
+}
+
+vec depDoublePiFun( vec p ){
+  //p must have 2 columns
+  vec pi(2);
+  pi(0) = p(0);
+  pi(1) = p(1) * (1 - p(0));
+  return(pi);
+}
+
+vec piFun( vec p , std::string pi_fun ){
+  if(pi_fun == "removalPiFun"){
+    return(removalPiFun(p));
+  } else if(pi_fun == "doublePiFun"){
+    return(doublePiFun(p));
+  } else if(pi_fun == "depDoublePiFun"){
+    return(depDoublePiFun(p));
+  }
+}

--- a/src/pifun.h
+++ b/src/pifun.h
@@ -1,0 +1,8 @@
+#ifndef _unmarked_PIFUN_H
+#define _unmarked_PIFUN_H
+
+#include <RcppArmadillo.h>
+
+arma::vec piFun( arma::vec p, std::string pi_fun );
+
+#endif


### PR DESCRIPTION
Add dependent double observer sampling as built-in option for `gmultmix` and `multinomPois`, with `type = 'depDouble'`. 

I also did a little reorganization to split the piFuns out into their own R file (and their own cpp file), to make it more clear they are shared between functions, and to make adding future piFuns easier. Updated the docs to reflect the changes and added relevant tests.

Finally, I corrected a related bug when dealing with missing values in the gmultmix C engine.