### PR TITLE
Throw error when tlength!=nrow(y) in gdistsamp

### DIFF
--- a/R/unmarkedFrame.R
+++ b/R/unmarkedFrame.R
@@ -408,6 +408,11 @@ unmarkedFrameGDS <- function(y, siteCovs, numPrimary,
             stop("tlength cannot be specified with point transect data")
         tlength <- rep(1, nrow(y))
         }
+    if(identical(survey, "line")) {
+      if(length(tlength) != nrow(y)) {
+        stop("tlength should be a vector with length(tlength)==nrow(y)")
+      }
+    }
 
     umf@yearlySiteCovs <- yearlySiteCovs
     umf <- as(umf, "unmarkedFrameGDS")

--- a/inst/unitTests/runit.distsamp.r
+++ b/inst/unitTests/runit.distsamp.r
@@ -1,6 +1,11 @@
 test.distsamp.covs <- function() {
     y <- matrix(rep(4:1, 10), 5, 2, byrow=TRUE)
     siteCovs <- data.frame(x = c(0, 2, 3, 4, 1))
+    #Check error thrown when length(tlength!=nrow(y))
+    checkException(unmarkedFrameDS(y = y, siteCovs = siteCovs,
+        dist.breaks=c(0, 5, 10)/1000, survey="line", tlength=rep(1, (5-1)),
+        unitsIn="km"))
+
     umf <- unmarkedFrameDS(y = y, siteCovs = siteCovs,
         dist.breaks=c(0, 5, 10)/1000, survey="line", tlength=rep(1, 5),
         unitsIn="km")

--- a/inst/unitTests/runit.gdistsamp.R
+++ b/inst/unitTests/runit.gdistsamp.R
@@ -27,6 +27,11 @@ test.gdistsamp.covs <- function() {
     }
     y <- matrix(y, nrow=R) # convert array to matrix
 
+    #Check that error thrown when length(tlength)!=nrow(y)
+    checkException(unmarkedFrameGDS(y = y, survey="line", unitsIn="m",
+                            dist.breaks=breaks,
+                            tlength=rep(transect.length, (R-1)), numPrimary=T))
+
     # Organize data
     umf <- unmarkedFrameGDS(y = y, survey="line", unitsIn="m",
                             dist.breaks=breaks,


### PR DESCRIPTION
Modification to `unmarkedFrameGDS` that fixes #101. The `unmarkedFrameDS` function already handled this situation.