### PR TITLE
C++ engine for gdistsamp

### DIFF
--- a/R/gdistsamp.R
+++ b/R/gdistsamp.R
@@ -194,7 +194,8 @@ halfnorm = {
                         }
                     })
                 cp <- p * u[i,] * phi[i, t]
-                cp[J+1] <- 1 - sum(cp)
+                cp[J+1] <- 1 - sum(cp[which(!naflag[i,t,])])
+                if(!is.na(cp[J+1]) && cp[J+1]<0){ cp[J+1] <- 0 }
 
                 mn[, t] <- lfac.k - lfac.kmyt[i, t,] +
                     sum(y[i, t, !naflag[i,t,]] *
@@ -263,7 +264,8 @@ exp = {
                         }
                     })
                 cp <- p * u[i,] * phi[i, t]
-                cp[J+1] <- 1 - sum(cp)
+                cp[J+1] <- 1 - sum(cp[which(!naflag[i,t,])]) 
+                if(!is.na(cp[J+1]) && cp[J+1]<0){ cp[J+1] <- 0 }
                 mn[, t] <- lfac.k - lfac.kmyt[i, t,] +
                     sum(y[i, t, !naflag[i,t,]] *
                     log(cp[which(!naflag[i,t,])])) +
@@ -331,7 +333,8 @@ hazard = {
                         }
                     })
                 cp <- p * u[i,] * phi[i, t]
-                cp[J+1] <- 1 - sum(cp)
+                cp[J+1] <- 1 - sum(cp[which(!naflag[i,t,])])
+                if(!is.na(cp[J+1]) && cp[J+1]<0){ cp[J+1] <- 0 }
                 mn[, t] <- lfac.k - lfac.kmyt[i, t,] +
                     sum(y[i, t, !naflag[i,t,]] *
                     log(cp[which(!naflag[i,t,])])) +
@@ -369,7 +372,8 @@ uniform = {
                 if(all(naflag[i,t,]))
                     next
                 cp <- p * u[i,] * phi[i, t]
-                cp[J+1] <- 1 - sum(cp)
+                cp[J+1] <- 1 - sum(cp[which(!naflag[i,t,])])
+                if(!is.na(cp[J+1]) && cp[J+1]<0){ cp[J+1] <- 0 }
                 mn[, t] <- lfac.k - lfac.kmyt[i, t,] +
                     sum(y[i, t, !naflag[i,t,]] *
                     log(cp[which(!naflag[i,t,])])) +
@@ -392,7 +396,7 @@ if(engine =="C" & keyfun %in% c('halfnorm','uniform')){
   naflag_long <- long_format(naflag)
   kmytC <- kmyt
   kmytC[which(is.na(kmyt))] <- 0
-  if(output!='Density'){
+  if(output!='density'){
     A <- rep(1, M)
   }
 

--- a/R/gdistsamp.R
+++ b/R/gdistsamp.R
@@ -3,13 +3,13 @@ gdistsamp <- function(lambdaformula, phiformula, pformula, data,
     keyfun=c("halfnorm", "exp", "hazard", "uniform"),
     output=c("abund", "density"), unitsOut=c("ha", "kmsq"),
     mixture=c('P', 'NB'), K,
-    starts, method = "BFGS", se = TRUE, engine=c("R","C"),
+    starts, method = "BFGS", se = TRUE, engine=c("C","R"),
     rel.tol=1e-4, ...)
 {
 if(!is(data, "unmarkedFrameGDS"))
     stop("Data is not of class unmarkedFrameGDS.")
 
-engine <- match.arg(engine, c("R", "C"))
+engine <- match.arg(engine, c("C", "R"))
 keyfun <- match.arg(keyfun)
 if(!keyfun %in% c("halfnorm", "exp", "hazard", "uniform"))
     stop("keyfun must be 'halfnorm', 'exp', 'hazard', or 'uniform'")
@@ -387,7 +387,7 @@ uniform = {
     }
 })
 
-if(engine =="C" & keyfun %in% c('halfnorm','uniform','exp')){
+if(engine =="C"){
   long_format <- function(x){
     out <- matrix(aperm(x,c(1,3,2)),nrow=nrow(x),ncol=dim(x)[2]*dim(x)[3])
     as.vector(t(out))

--- a/inst/unitTests/runit.gdistsamp.R
+++ b/inst/unitTests/runit.gdistsamp.R
@@ -323,3 +323,77 @@ test.gdistsamp.exp <- function(){
                                     0.89988),tol=1e-4)
     checkEqualsNumeric(coef(fm_R),coef(fm_C),tol=1e-4)
 }
+
+test.gdistsamp.hazard <- function(){
+    #Line  
+    set.seed(343)
+    R <- 30 
+    T <- 3  
+    strip.width <- 50
+    transect.length <- 200 #Area != 1
+    breaks <- seq(0, 50, by=10)
+    
+    covs <- as.data.frame(matrix(rnorm(R*T),ncol=T))
+    names(covs) <- paste0('par',1:3)
+    
+    beta <- c(0.4,0.3,0.6)
+    lambda <- exp(1.3 + beta[1]*covs$par1) 
+    phi <- plogis(as.matrix(0.4 + beta[2]*covs)) 
+    sigma <- exp(as.matrix(3 + beta[3]*covs)) 
+    J <- length(breaks)-1
+    y <- array(0, c(R, J, T))
+    for(i in 1:R) {
+        M <- rpois(1, lambda[i]) # Individuals within the 1-ha strip
+        for(t in 1:T) {
+            # Distances from point
+            d <- runif(M, 0, strip.width)
+            # Detection process
+            if(length(d)) {
+                cp <- phi[i,t]*exp(-d^2 / (2 * sigma[i,t]^2)) # half-normal w/ g(0)<1
+                d <- d[rbinom(length(d), 1, cp) == 1]
+                y[i,,t] <- table(cut(d, breaks, include.lowest=TRUE))
+            }
+        }
+    }
+    y <- matrix(y, nrow=R) # convert array to matrix
+    
+    #With covariates
+    umf <- unmarkedFrameGDS(y = y, siteCovs=covs, yearlySiteCovs=covs,
+                            survey="line", unitsIn="m",
+                            dist.breaks=breaks,
+                            tlength=rep(transect.length, R), numPrimary=T)
+
+    fm_R <- gdistsamp(~par1, ~par2, ~par3, umf, output="density", se=FALSE, 
+                      keyfun="hazard",engine="R")
+    fm_C <- gdistsamp(~par1, ~par2, ~par3, umf, output="density", se=FALSE, 
+                      keyfun="hazard",engine="C")
+
+    checkEqualsNumeric(coef(fm_R),c(1.29425,0.54233,-1.41658,-0.09267,
+                                    3.45436,-0.19978,0.8270215),tol=1e-4)
+    checkEqualsNumeric(coef(fm_R),coef(fm_C),tol=1e-4)
+
+    #Point
+    set.seed(123)
+    data(issj)
+    covs <- issj[,c("elevation","forest","chaparral")]
+    area <- pi*300^2 / 100^2
+    # Area in ha
+    jayumf <- unmarkedFrameGDS(y=as.matrix(issj[,1:3]), 
+                               siteCovs=data.frame(covs, area), 
+                               yearlySiteCovs=data.frame(covs),
+                               numPrimary=1,
+                              dist.breaks=c(0, 100, 200, 300), unitsIn="m", 
+                              survey="point")
+    sc <- siteCovs(jayumf)
+    sc.s <- scale(sc)
+    sc.s[,"area"] <- pi*300^2 / 10000 # Don't standardize area
+    covs <- siteCovs(jayumf) <- sc.s
+    fm_R <- gdistsamp(~elevation, ~1, ~chaparral, jayumf, output='density',
+                      keyfun="hazard",engine="R", se=F)
+    fm_C <- gdistsamp(~elevation, ~1, ~chaparral, jayumf, output='density',
+                      keyfun="hazard",engine="C", se=F)
+
+    checkEqualsNumeric(coef(fm_R),c(0.70099,-0.23473,1.38888,
+                                    1.40786,0.44896),tol=1e-4)
+    checkEqualsNumeric(coef(fm_R),coef(fm_C),tol=1e-4)
+}

--- a/inst/unitTests/runit.gdistsamp.R
+++ b/inst/unitTests/runit.gdistsamp.R
@@ -46,3 +46,205 @@ test.gdistsamp.covs <- function() {
     checkEqualsNumeric(bup(re1, "mode")[1:7], c(3,5,3,5,5,2,5))
 
 }
+
+test.gdistsamp.halfnorm <- function(){
+    #Line  
+    set.seed(343)
+    R <- 30 
+    T <- 3  
+    strip.width <- 50
+    transect.length <- 200 #Area != 1
+    breaks <- seq(0, 50, by=10)
+    
+    covs <- as.data.frame(matrix(rnorm(R*T),ncol=T))
+    names(covs) <- paste0('par',1:3)
+    
+    beta <- c(0.4,0.3,0.6)
+    lambda <- exp(1.3 + beta[1]*covs$par1) 
+    phi <- plogis(as.matrix(0.4 + beta[2]*covs)) 
+    sigma <- exp(as.matrix(3 + beta[3]*covs)) 
+    J <- length(breaks)-1
+    y <- array(0, c(R, J, T))
+    for(i in 1:R) {
+        M <- rpois(1, lambda[i]) # Individuals within the 1-ha strip
+        for(t in 1:T) {
+            # Distances from point
+            d <- runif(M, 0, strip.width)
+            # Detection process
+            if(length(d)) {
+                cp <- phi[i,t]*exp(-d^2 / (2 * sigma[i,t]^2)) # half-normal w/ g(0)<1
+                d <- d[rbinom(length(d), 1, cp) == 1]
+                y[i,,t] <- table(cut(d, breaks, include.lowest=TRUE))
+            }
+        }
+    }
+    y <- matrix(y, nrow=R) # convert array to matrix
+    
+    umf <- unmarkedFrameGDS(y = y, survey="line", unitsIn="m",
+                            dist.breaks=breaks,
+                            tlength=rep(transect.length, R), numPrimary=T)
+    
+    #When output = density
+    fm_R <- gdistsamp(~1, ~1, ~1, umf, output="density", se=FALSE, engine="R")
+    fm_C <- gdistsamp(~1, ~1, ~1, umf, output="density", se=FALSE, engine="C")
+    
+    checkEqualsNumeric(coef(fm_R),c(0.6584008,-0.4440278,3.4817094),tol=1e-4)
+    checkEqualsNumeric(coef(fm_R),coef(fm_C),tol=1e-4)
+ 
+    #When output = abundance
+    fm_R <- gdistsamp(~1, ~1, ~1, umf, output="abund", se=FALSE, engine="R")
+    fm_C <- gdistsamp(~1, ~1, ~1, umf, output="abund", se=FALSE, engine="C")
+    
+    checkEqualsNumeric(coef(fm_R),c(1.35067,-0.44262,3.48149),tol=1e-4)
+    checkEqualsNumeric(coef(fm_R),coef(fm_C),tol=1e-4)
+
+    #With covariates
+    umf <- unmarkedFrameGDS(y = y, siteCovs=covs, yearlySiteCovs=covs,
+                            survey="line", unitsIn="m",
+                            dist.breaks=breaks,
+                            tlength=rep(transect.length, R), numPrimary=T)
+
+    fm_R <- gdistsamp(~par1, ~par2, ~par3, umf, output="density", se=FALSE, engine="R")
+    fm_C <- gdistsamp(~par1, ~par2, ~par3, umf, output="density", se=FALSE, engine="C")
+
+    checkEqualsNumeric(coef(fm_R),c(1.24510,0.54419,-1.28146,-0.109737,
+                                    3.46295,-0.13228),tol=1e-4)
+    checkEqualsNumeric(coef(fm_R),coef(fm_C),tol=1e-4)
+
+    #Negative binomial
+    fm_R <- gdistsamp(~par1, ~par2, ~par3, umf, output="density", se=FALSE, 
+                      mixture="NB", engine="R")
+    fm_C <- gdistsamp(~par1, ~par2, ~par3, umf, output="density", se=FALSE, 
+                      mixture="NB", engine="C")
+
+    checkEqualsNumeric(coef(fm_R),c(1.41241,0.52442,-1.49024,-0.10546,
+                                    3.46284,-0.129831,3.16892),tol=1e-4)
+    checkEqualsNumeric(coef(fm_R),coef(fm_C),tol=1e-4)
+    
+    #With missing values
+    yna <- y
+    yna[1,c(1,6)] <- NA
+    umf <- unmarkedFrameGDS(y = yna, siteCovs=covs, yearlySiteCovs=covs,
+                            survey="line", unitsIn="m",
+                            dist.breaks=breaks,
+                            tlength=rep(transect.length, R), numPrimary=T)
+    
+    fm_R <- gdistsamp(~par1, ~par2, ~par3, umf, output="density", 
+                      se=FALSE, engine="R")
+    fm_C <- gdistsamp(~par1, ~par2, ~par3, umf, output="density", 
+                      se=FALSE, engine="C")
+
+    checkEqualsNumeric(coef(fm_R),c(1.27748,0.53940,-1.31593,-0.10877,
+                                    3.45949,-0.13309),tol=1e-4)
+    checkEqualsNumeric(coef(fm_R),coef(fm_C),tol=1e-4)
+
+    #With an entire session missing
+    yna <- y
+    yna[1,1:J] <- NA
+    umf <- unmarkedFrameGDS(y = yna, siteCovs=covs, yearlySiteCovs=covs,
+                            survey="line", unitsIn="m",
+                            dist.breaks=breaks,
+                            tlength=rep(transect.length, R), numPrimary=T)
+    
+    fm_R <- gdistsamp(~par1, ~par2, ~par3, umf, output="density", 
+                      se=FALSE, engine="R")
+    fm_C <- gdistsamp(~par1, ~par2, ~par3, umf, output="density", 
+                      se=FALSE, engine="C")
+
+    checkEqualsNumeric(coef(fm_R),c(1.30815,0.53527,-1.35387,-0.11038,
+                                    3.46293,-0.13458),tol=1e-4)
+    checkEqualsNumeric(coef(fm_R),coef(fm_C),tol=1e-4)
+
+    #Point
+    set.seed(123)
+    data(issj)
+    covs <- issj[,c("elevation","forest","chaparral")]
+    area <- pi*300^2 / 100^2
+    # Area in ha
+    jayumf <- unmarkedFrameGDS(y=as.matrix(issj[,1:3]), 
+                               siteCovs=data.frame(covs, area), 
+                               yearlySiteCovs=data.frame(covs),
+                               numPrimary=1,
+                              dist.breaks=c(0, 100, 200, 300), unitsIn="m", 
+                              survey="point")
+    sc <- siteCovs(jayumf)
+    sc.s <- scale(sc)
+    sc.s[,"area"] <- pi*300^2 / 10000 # Don't standardize area
+    covs <- siteCovs(jayumf) <- sc.s
+    fm_R <- gdistsamp(~elevation, ~1, ~chaparral, jayumf, output='density',
+                      engine="R", se=F)
+    fm_C <- gdistsamp(~elevation, ~1, ~chaparral, jayumf, output='density',
+                      engine="C", se=F)
+
+    checkEqualsNumeric(coef(fm_R),c(-2.42178,-0.17874,4.38373,0.62425),tol=1e-4)
+    checkEqualsNumeric(coef(fm_R),coef(fm_C),tol=1e-4)
+}
+
+test.gdistsamp.uniform <- function(){
+    #Line
+    set.seed(343)
+    R <- 30 
+    T <- 3  
+    strip.width <- 50
+    transect.length <- 200 #Area != 1
+    breaks <- seq(0, 50, by=10)
+    
+    covs <- as.data.frame(matrix(rnorm(R*T),ncol=T))
+    names(covs) <- paste0('par',1:3)
+    
+    beta <- c(0.4,0.3,0.6)
+    lambda <- exp(1.3 + beta[1]*covs$par1) 
+    phi <- plogis(as.matrix(0.4 + beta[2]*covs)) 
+    sigma <- exp(as.matrix(3 + beta[3]*covs)) 
+    J <- length(breaks)-1
+    y <- array(0, c(R, J, T))
+    for(i in 1:R) {
+        M <- rpois(1, lambda[i]) # Individuals within the 1-ha strip
+        for(t in 1:T) {
+            # Distances from point
+            d <- runif(M, 0, strip.width)
+            # Detection process
+            if(length(d)) {
+                cp <- phi[i,t]*exp(-d^2 / (2 * sigma[i,t]^2)) # half-normal w/ g(0)<1
+                d <- d[rbinom(length(d), 1, cp) == 1]
+                y[i,,t] <- table(cut(d, breaks, include.lowest=TRUE))
+            }
+        }
+    }
+    y <- matrix(y, nrow=R) # convert array to matrix
+    
+    umf <- unmarkedFrameGDS(y = y, siteCovs=covs, yearlySiteCovs=covs,
+                            survey="line", unitsIn="m",
+                            dist.breaks=breaks,
+                            tlength=rep(transect.length, R), numPrimary=T)
+
+    fm_R <- gdistsamp(~par1, ~par2, ~1, umf, output="density", 
+                      keyfun="uniform", se=FALSE, engine="R")
+    fm_C <- gdistsamp(~par1, ~par2, ~1, umf, output="density", 
+                      keyfun="uniform", se=FALSE, engine="C")
+    
+    checkEqualsNumeric(coef(fm_R),c(1.17120,0.54748,-1.60963,-0.13009),tol=1e-4)
+    checkEqualsNumeric(coef(fm_R),coef(fm_C),tol=1e-4)
+
+    #Point: doesn't work with this dataset, find another one?
+    #OR maybe uniform just doesn't work with point?
+    set.seed(123)
+    data(issj)
+    covs <- issj[,c("elevation","forest","chaparral")]
+    area <- pi*300^2 / 100^2
+    # Area in ha
+    jayumf <- unmarkedFrameGDS(y=as.matrix(issj[,1:3]), 
+                               siteCovs=data.frame(covs, area), 
+                               yearlySiteCovs=data.frame(covs),
+                               numPrimary=1,
+                              dist.breaks=c(0, 100, 200, 300), unitsIn="m", 
+                              survey="point")
+    sc <- siteCovs(jayumf)
+    sc.s <- scale(sc)
+    sc.s[,"area"] <- pi*300^2 / 10000 # Don't standardize area
+    covs <- siteCovs(jayumf) <- sc.s
+    checkException(gdistsamp(~1, ~1, ~1, jayumf, output='density',
+                      keyfun='uniform', engine="R", se=F))
+    checkException(gdistsamp(~elevation, ~1, ~1, jayumf, output='density',
+                      keyfun='uniform', engine="C", se=F))
+}

--- a/inst/unitTests/runit.gdistsamp.R
+++ b/inst/unitTests/runit.gdistsamp.R
@@ -248,3 +248,78 @@ test.gdistsamp.uniform <- function(){
     checkException(gdistsamp(~elevation, ~1, ~1, jayumf, output='density',
                       keyfun='uniform', engine="C", se=F))
 }
+
+
+test.gdistsamp.exp <- function(){
+    #Line  
+    set.seed(343)
+    R <- 30 
+    T <- 3  
+    strip.width <- 50
+    transect.length <- 200 #Area != 1
+    breaks <- seq(0, 50, by=10)
+    
+    covs <- as.data.frame(matrix(rnorm(R*T),ncol=T))
+    names(covs) <- paste0('par',1:3)
+    
+    beta <- c(0.4,0.3,0.6)
+    lambda <- exp(1.3 + beta[1]*covs$par1) 
+    phi <- plogis(as.matrix(0.4 + beta[2]*covs)) 
+    sigma <- exp(as.matrix(3 + beta[3]*covs)) 
+    J <- length(breaks)-1
+    y <- array(0, c(R, J, T))
+    for(i in 1:R) {
+        M <- rpois(1, lambda[i]) # Individuals within the 1-ha strip
+        for(t in 1:T) {
+            # Distances from point
+            d <- runif(M, 0, strip.width)
+            # Detection process
+            if(length(d)) {
+                cp <- phi[i,t]*exp(-d^2 / (2 * sigma[i,t]^2)) # half-normal w/ g(0)<1
+                d <- d[rbinom(length(d), 1, cp) == 1]
+                y[i,,t] <- table(cut(d, breaks, include.lowest=TRUE))
+            }
+        }
+    }
+    y <- matrix(y, nrow=R) # convert array to matrix
+    
+    #With covariates
+    umf <- unmarkedFrameGDS(y = y, siteCovs=covs, yearlySiteCovs=covs,
+                            survey="line", unitsIn="m",
+                            dist.breaks=breaks,
+                            tlength=rep(transect.length, R), numPrimary=T)
+
+    fm_R <- gdistsamp(~par1, ~par2, ~par3, umf, output="density", se=FALSE, 
+                      keyfun="exp",engine="R")
+    fm_C <- gdistsamp(~par1, ~par2, ~par3, umf, output="density", se=FALSE, 
+                      keyfun="exp",engine="C")
+
+    checkEqualsNumeric(coef(fm_R),c(1.28243,0.54312,-1.16608,-0.101122,
+                                    3.86666,-0.2492846),tol=1e-4)
+    checkEqualsNumeric(coef(fm_R),coef(fm_C),tol=1e-4)
+
+    #Point
+    set.seed(123)
+    data(issj)
+    covs <- issj[,c("elevation","forest","chaparral")]
+    area <- pi*300^2 / 100^2
+    # Area in ha
+    jayumf <- unmarkedFrameGDS(y=as.matrix(issj[,1:3]), 
+                               siteCovs=data.frame(covs, area), 
+                               yearlySiteCovs=data.frame(covs),
+                               numPrimary=1,
+                              dist.breaks=c(0, 100, 200, 300), unitsIn="m", 
+                              survey="point")
+    sc <- siteCovs(jayumf)
+    sc.s <- scale(sc)
+    sc.s[,"area"] <- pi*300^2 / 10000 # Don't standardize area
+    covs <- siteCovs(jayumf) <- sc.s
+    fm_R <- gdistsamp(~elevation, ~1, ~chaparral, jayumf, output='density',
+                      keyfun="exp",engine="R", se=F)
+    fm_C <- gdistsamp(~elevation, ~1, ~chaparral, jayumf, output='density',
+                      keyfun="exp",engine="C", se=F)
+
+    checkEqualsNumeric(coef(fm_R),c(-1.531876,-0.2037537,3.870335,
+                                    0.89988),tol=1e-4)
+    checkEqualsNumeric(coef(fm_R),coef(fm_C),tol=1e-4)
+}

--- a/man/gdistsamp.Rd
+++ b/man/gdistsamp.Rd
@@ -12,7 +12,7 @@ to be modeled using the negative binomial distribution.
 gdistsamp(lambdaformula, phiformula, pformula, data, keyfun =
 c("halfnorm", "exp", "hazard", "uniform"), output = c("abund",
 "density"), unitsOut = c("ha", "kmsq"), mixture = c("P", "NB"), K,
-starts, method = "BFGS", se = TRUE, engine=c("R","C"), rel.tol=1e-4, ...)
+starts, method = "BFGS", se = TRUE, engine=c("C","R"), rel.tol=1e-4, ...)
 }
 \arguments{
   \item{lambdaformula}{

--- a/man/gdistsamp.Rd
+++ b/man/gdistsamp.Rd
@@ -12,7 +12,7 @@ to be modeled using the negative binomial distribution.
 gdistsamp(lambdaformula, phiformula, pformula, data, keyfun =
 c("halfnorm", "exp", "hazard", "uniform"), output = c("abund",
 "density"), unitsOut = c("ha", "kmsq"), mixture = c("P", "NB"), K,
-starts, method = "BFGS", se = TRUE, rel.tol=1e-4, ...)
+starts, method = "BFGS", se = TRUE, engine=c("R","C"), rel.tol=1e-4, ...)
 }
 \arguments{
   \item{lambdaformula}{
@@ -53,6 +53,10 @@ starts, method = "BFGS", se = TRUE, rel.tol=1e-4, ...)
 }
   \item{se}{
       logical specifying whether or not to compute standard errors.
+}
+  \item{engine}{
+      Either "C" to use fast C++ code or "R" to use native R code during the 
+      optimization.
 }
 \item{rel.tol}{relative accuracy for the integration of the detection function.
     See \link{integrate}. You might try adjusting this if you get an error

--- a/src/init.c
+++ b/src/init.c
@@ -12,7 +12,7 @@ extern SEXP getDetVecs(SEXP y_arr, SEXP mp_arr, SEXP J_i, SEXP tin, SEXP K_) ;
 extern SEXP getSingleDetVec(SEXP y_, SEXP mp_, SEXP K_);
 extern SEXP nll_distsamp( SEXP y_, SEXP lam_, SEXP sig_, SEXP scale_, SEXP a_, SEXP u_, SEXP w_, SEXP db_, SEXP keyfun_, SEXP survey_, SEXP reltol_ );
 extern SEXP nll_gmultmix( SEXP betaR, SEXP mixtureR, SEXP pi_funR, SEXP XlamR, SEXP Xlam_offsetR, SEXP XphiR, SEXP Xphi_offsetR, SEXP XdetR, SEXP Xdet_offsetR, SEXP kR, SEXP lfac_kR, SEXP lfac_kmytR, SEXP kmytR, SEXP yR, SEXP naflagR, SEXP finR, SEXP nPr, SEXP nLPr, SEXP nPPr, SEXP nDPr ) ;
-extern SEXP nll_gdistsamp(SEXP beta_, SEXP mixture_, SEXP keyfun_, SEXP survey_, SEXP Xlam_, SEXP Xlam_offset_, SEXP A_, SEXP Xphi_, SEXP Xphi_offset_, SEXP Xdet_, SEXP Xdet_offset_, SEXP db_, SEXP a_, SEXP u_, SEXP w_, SEXP k_, SEXP lfac_k_, SEXP lfac_kmyt_, SEXP kmyt_, SEXP y_, SEXP naflag_, SEXP fin_, SEXP nP_, SEXP nLP_, SEXP nPP_, SEXP nDP_, SEXP nSP_, SEXP nOP_) ;
+extern SEXP nll_gdistsamp(SEXP beta_, SEXP mixture_, SEXP keyfun_, SEXP survey_, SEXP Xlam_, SEXP Xlam_offset_, SEXP A_, SEXP Xphi_, SEXP Xphi_offset_, SEXP Xdet_, SEXP Xdet_offset_, SEXP db_, SEXP a_, SEXP u_, SEXP w_, SEXP k_, SEXP lfac_k_, SEXP lfac_kmyt_, SEXP kmyt_, SEXP y_, SEXP naflag_, SEXP fin_, SEXP nP_, SEXP nLP_, SEXP nPP_, SEXP nDP_, SEXP nSP_, SEXP nOP_, SEXP rel_tol_) ;
 extern SEXP nll_gpcount( SEXP y_, SEXP Xlam_, SEXP Xphi_, SEXP Xp_, SEXP beta_lam_, SEXP beta_phi_, SEXP beta_p_, SEXP log_alpha_, SEXP Xlam_offset_, SEXP Xphi_offset_, SEXP Xp_offset_, SEXP M_, SEXP mixture_, SEXP numPrimary_ ) ;
 extern SEXP nll_multinomPois( SEXP betaR, SEXP pi_funR, SEXP XlamR, SEXP Xlam_offsetR, SEXP XdetR, SEXP Xdet_offsetR, SEXP yR, SEXP navecR, SEXP nPr, SEXP nAPr ) ;
 extern SEXP nll_occu( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_psiR, SEXP beta_pR, SEXP ndR, SEXP knownOccR, SEXP navecR, SEXP X_offsetR, SEXP V_offsetR );
@@ -27,7 +27,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"getSingleDetVec", (DL_FUNC) &getSingleDetVec,  3},
     {"nll_distsamp",    (DL_FUNC) &nll_distsamp,    11},
     {"nll_gmultmix",    (DL_FUNC) &nll_gmultmix,    20},
-    {"nll_gdistsamp",   (DL_FUNC) &nll_gdistsamp,   28},
+    {"nll_gdistsamp",   (DL_FUNC) &nll_gdistsamp,   29},
     {"nll_gpcount",     (DL_FUNC) &nll_gpcount,     14},
     {"nll_multinomPois",(DL_FUNC) &nll_multinomPois,10},
     {"nll_occu",        (DL_FUNC) &nll_occu,        10},

--- a/src/init.c
+++ b/src/init.c
@@ -12,6 +12,7 @@ extern SEXP getDetVecs(SEXP y_arr, SEXP mp_arr, SEXP J_i, SEXP tin, SEXP K_) ;
 extern SEXP getSingleDetVec(SEXP y_, SEXP mp_, SEXP K_);
 extern SEXP nll_distsamp( SEXP y_, SEXP lam_, SEXP sig_, SEXP scale_, SEXP a_, SEXP u_, SEXP w_, SEXP db_, SEXP keyfun_, SEXP survey_, SEXP reltol_ );
 extern SEXP nll_gmultmix( SEXP betaR, SEXP mixtureR, SEXP pi_funR, SEXP XlamR, SEXP Xlam_offsetR, SEXP XphiR, SEXP Xphi_offsetR, SEXP XdetR, SEXP Xdet_offsetR, SEXP kR, SEXP lfac_kR, SEXP lfac_kmytR, SEXP kmytR, SEXP yR, SEXP naflagR, SEXP finR, SEXP nPr, SEXP nLPr, SEXP nPPr, SEXP nDPr ) ;
+extern SEXP nll_gdistsamp(SEXP beta_, SEXP mixture_, SEXP keyfun_, SEXP Xlam_, SEXP Xlam_offset_, SEXP A_, SEXP Xphi_, SEXP Xphi_offset_, SEXP Xdet_, SEXP Xdet_offset_, SEXP db_, SEXP a_, SEXP u_, SEXP w_, SEXP k_, SEXP lfac_k_, SEXP lfac_kmyt_, SEXP kmyt_, SEXP y_, SEXP naflag_, SEXP fin_, SEXP nP_, SEXP nLP_, SEXP nPP_, SEXP nDP_, SEXP nSP_, SEXP nOP_) ;
 extern SEXP nll_gpcount( SEXP y_, SEXP Xlam_, SEXP Xphi_, SEXP Xp_, SEXP beta_lam_, SEXP beta_phi_, SEXP beta_p_, SEXP log_alpha_, SEXP Xlam_offset_, SEXP Xphi_offset_, SEXP Xp_offset_, SEXP M_, SEXP mixture_, SEXP numPrimary_ ) ;
 extern SEXP nll_multinomPois( SEXP betaR, SEXP pi_funR, SEXP XlamR, SEXP Xlam_offsetR, SEXP XdetR, SEXP Xdet_offsetR, SEXP yR, SEXP navecR, SEXP nPr, SEXP nAPr ) ;
 extern SEXP nll_occu( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_psiR, SEXP beta_pR, SEXP ndR, SEXP knownOccR, SEXP navecR, SEXP X_offsetR, SEXP V_offsetR );
@@ -26,6 +27,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"getSingleDetVec", (DL_FUNC) &getSingleDetVec,  3},
     {"nll_distsamp",    (DL_FUNC) &nll_distsamp,    11},
     {"nll_gmultmix",    (DL_FUNC) &nll_gmultmix,    20},
+    {"nll_gdistsamp",   (DL_FUNC) &nll_gdistsamp,   27},
     {"nll_gpcount",     (DL_FUNC) &nll_gpcount,     14},
     {"nll_multinomPois",(DL_FUNC) &nll_multinomPois,10},
     {"nll_occu",        (DL_FUNC) &nll_occu,        10},

--- a/src/init.c
+++ b/src/init.c
@@ -12,7 +12,7 @@ extern SEXP getDetVecs(SEXP y_arr, SEXP mp_arr, SEXP J_i, SEXP tin, SEXP K_) ;
 extern SEXP getSingleDetVec(SEXP y_, SEXP mp_, SEXP K_);
 extern SEXP nll_distsamp( SEXP y_, SEXP lam_, SEXP sig_, SEXP scale_, SEXP a_, SEXP u_, SEXP w_, SEXP db_, SEXP keyfun_, SEXP survey_, SEXP reltol_ );
 extern SEXP nll_gmultmix( SEXP betaR, SEXP mixtureR, SEXP pi_funR, SEXP XlamR, SEXP Xlam_offsetR, SEXP XphiR, SEXP Xphi_offsetR, SEXP XdetR, SEXP Xdet_offsetR, SEXP kR, SEXP lfac_kR, SEXP lfac_kmytR, SEXP kmytR, SEXP yR, SEXP naflagR, SEXP finR, SEXP nPr, SEXP nLPr, SEXP nPPr, SEXP nDPr ) ;
-extern SEXP nll_gdistsamp(SEXP beta_, SEXP mixture_, SEXP keyfun_, SEXP Xlam_, SEXP Xlam_offset_, SEXP A_, SEXP Xphi_, SEXP Xphi_offset_, SEXP Xdet_, SEXP Xdet_offset_, SEXP db_, SEXP a_, SEXP u_, SEXP w_, SEXP k_, SEXP lfac_k_, SEXP lfac_kmyt_, SEXP kmyt_, SEXP y_, SEXP naflag_, SEXP fin_, SEXP nP_, SEXP nLP_, SEXP nPP_, SEXP nDP_, SEXP nSP_, SEXP nOP_) ;
+extern SEXP nll_gdistsamp(SEXP beta_, SEXP mixture_, SEXP keyfun_, SEXP survey_, SEXP Xlam_, SEXP Xlam_offset_, SEXP A_, SEXP Xphi_, SEXP Xphi_offset_, SEXP Xdet_, SEXP Xdet_offset_, SEXP db_, SEXP a_, SEXP u_, SEXP w_, SEXP k_, SEXP lfac_k_, SEXP lfac_kmyt_, SEXP kmyt_, SEXP y_, SEXP naflag_, SEXP fin_, SEXP nP_, SEXP nLP_, SEXP nPP_, SEXP nDP_, SEXP nSP_, SEXP nOP_) ;
 extern SEXP nll_gpcount( SEXP y_, SEXP Xlam_, SEXP Xphi_, SEXP Xp_, SEXP beta_lam_, SEXP beta_phi_, SEXP beta_p_, SEXP log_alpha_, SEXP Xlam_offset_, SEXP Xphi_offset_, SEXP Xp_offset_, SEXP M_, SEXP mixture_, SEXP numPrimary_ ) ;
 extern SEXP nll_multinomPois( SEXP betaR, SEXP pi_funR, SEXP XlamR, SEXP Xlam_offsetR, SEXP XdetR, SEXP Xdet_offsetR, SEXP yR, SEXP navecR, SEXP nPr, SEXP nAPr ) ;
 extern SEXP nll_occu( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_psiR, SEXP beta_pR, SEXP ndR, SEXP knownOccR, SEXP navecR, SEXP X_offsetR, SEXP V_offsetR );
@@ -27,7 +27,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"getSingleDetVec", (DL_FUNC) &getSingleDetVec,  3},
     {"nll_distsamp",    (DL_FUNC) &nll_distsamp,    11},
     {"nll_gmultmix",    (DL_FUNC) &nll_gmultmix,    20},
-    {"nll_gdistsamp",   (DL_FUNC) &nll_gdistsamp,   27},
+    {"nll_gdistsamp",   (DL_FUNC) &nll_gdistsamp,   28},
     {"nll_gpcount",     (DL_FUNC) &nll_gpcount,     14},
     {"nll_multinomPois",(DL_FUNC) &nll_multinomPois,10},
     {"nll_occu",        (DL_FUNC) &nll_occu,        10},

--- a/src/nll_gdistsamp.cpp
+++ b/src/nll_gdistsamp.cpp
@@ -92,7 +92,11 @@ SEXP nll_gdistsamp(SEXP beta_, SEXP mixture_, SEXP keyfun_, SEXP survey_,
   int R = y.size() / M;
   int J = R / T;
   
-  vec detParam = exp( Xdet * beta.subvec((nLP+nPP),(nLP+nPP+nDP-1)) + Xdet_offset);
+  vec detParam(M*T);
+  if(keyfun != "uniform"){
+    detParam = exp( Xdet * beta.subvec((nLP+nPP),(nLP+nPP+nDP-1)) 
+                        + Xdet_offset);
+  }
   
   int K = k.size();
   int t_ind = 0;

--- a/src/nll_gdistsamp.cpp
+++ b/src/nll_gdistsamp.cpp
@@ -1,0 +1,160 @@
+#include "nll_gdistsamp.h"
+
+using namespace Rcpp;
+using namespace arma;
+
+mat invlogit(const mat& inp ){
+  return(1 / (1 + exp(-1 * inp)));
+}
+
+vec p_halfnorm(const double& sigma, const std::string& survey, 
+               const NumericVector& db, const vec& w, const vec& a){
+  
+  int J = db.size() - 1;
+  vec p(J);
+
+  if(survey == "line"){
+    double f0 = 2 * R::dnorm(0.0, 0.0, sigma, 0);
+    IntegerVector idx1 = Range(1,db.size()-1);
+    vec p1 = Rcpp::dnorm(db[idx1], 0.0, sigma);
+    IntegerVector idx2 = Range(0,db.size()-2);
+    vec p2 = Rcpp::dnorm(db[idx2], 0.0, sigma);
+    vec int_ = 2 * (p1 - p2);
+    p = int_ / f0 / w;
+  } else if(survey == "point"){
+    for (int j; j<J; j++){
+      double s2 = pow(sigma,2);
+      double p1 = 1 - exp(-pow(db[j+1],2) / (2 * s2));
+      double p2 = 1 - exp(-pow(db[j],2) / (2 * s2)) 
+      double int_ = s2 * p1 - s2 * p2
+      p(j) = int_ * 2 * M_PI / a(j)
+    }
+  }
+  return(p);
+}
+
+SEXP nll_gdistsamp(SEXP beta_, SEXP mixture_, SEXP keyfun_,
+    SEXP Xlam_, SEXP Xlam_offset_, SEXP A_, SEXP Xphi_, SEXP Xphi_offset_, 
+    SEXP Xdet_, SEXP Xdet_offset_, SEXP db_, SEXP a_, SEXP u_, SEXP w_,
+    SEXP k_, SEXP lfac_k_, SEXP lfac_kmyt_, SEXP kmyt_, 
+    SEXP y_, SEXP naflag_, SEXP fin_, 
+    SEXP nP_, SEXP nLP_, SEXP nPP_, SEXP nDP_, SEXP nSP_, SEXP nOP_){
+
+  //Inputs
+  vec beta = as<vec>(beta_);
+  std::string mixture = as<std::string>(mixture_);
+  std::string keyfun = as<std::string>(keyfun_);
+
+  mat Xlam = as<mat>(Xlam_);
+  vec Xlam_offset = as<vec>(Xlam_offset_);
+  vec A = as<vec>(A_)
+  mat Xphi = as<mat>(Xphi_);
+  vec Xphi_offset = as<vec>(Xphi_offset_);
+  
+  mat Xdet = as<mat>(Xdet_);
+  vec Xdet_offset = as<vec>(Xdet_offset_);
+  
+  vec db = as<vec> db_;
+  vec w = as<vec> w_;
+  mat a = as<mat> a_;
+  mat u = as<mat> u_;
+
+  IntegerVector k(k_);
+  vec lfac_k = as<vec>(lfac_k_);
+  cube lfac_kmyt = as<cube>(lfac_kmyt_);
+  cube kmyt = as<cube>(kmyt_);
+
+  vec y = as<vec>(y_);
+  vec naflag = as<vec>(naflag_);
+  mat fin = as<mat>(fin_);
+
+  int nP = as<int>(nP_);
+  int nLP = as<int>(nLP_);
+  int nPP = as<int>(nPP_);
+  int nDP = as<int>(nDP_);
+  int nSP = as<int>(nSP_);
+  int nOP = as<int>(nOP_);
+
+  int M = Xlam.n_rows;
+  vec lambda = exp( Xlam * beta.subvec(0, (nLP - 1) ) + Xlam_offset ) % A;
+  
+  int T = Xphi.n_rows / M;
+  vec phi = ones(M*T);
+  if(T > 1){
+    phi = invlogit( Xphi * beta.subvec(nLP, (nLP+nPP-1)) + Xphi_offset);
+  }
+  
+  int R = y.size() / M;
+  int J = R / T;
+  
+  vec detParam = exp( Xdet * beta.subvec((nLP+nPP),(nLP+nPP+nDP-1)) + Xdet_offset);
+  
+  int K = k.size();
+  int t_ind = 0;
+  int y_ind = 0;
+  int p_ind = 0;
+  vec ll(M);
+  for (int m=0; m<M; m++){
+    vec f(K);
+    if(mixture == "P"){
+      f = dpois(k, lambda(m));
+    } else if(mixture == "NB"){
+      f = dnbinom_mu(k, exp(beta(nP-1)), lambda(m));
+    }
+
+    mat mn = zeros(K,T);
+    for(int t=0; t<T; t++){
+      int y_stop = y_ind + R - 1;
+      int p_stop = p_ind + J - 1;
+      vec na_sub = naflag.subvec(y_ind, y_stop); 
+
+      if( ! all(na_sub) ){
+
+        vec p1 = lfac_kmyt.subcube(span(m),span(t),span());
+        vec p2 = y.subvec(y_ind, y_stop);
+        
+        //calculate p here
+        vec p = ones(J); //uniform case
+
+        if (keyfun == "halfnorm"){
+          //detParam is sigma
+          vec p = p_halfnorm(detParam(t_ind), survey, db, w, a.row(m));
+        }
+        //other keyfuns
+
+        vec p3 = p % u.row(m) * phi(t_ind);
+        //the following line causes a segfault only in R CMD check,
+        //when kmyt contains NA values
+        vec p4 = kmyt.subcube(span(m),span(t),span());
+
+        if( any(na_sub)){
+          uvec ids = find(na_sub!=1);
+          p2 = p2.elem(ids);
+          p3 = p3.elem(ids);
+        }
+
+        double p5 = 1 - sum(p3);
+      
+        mn.col(t) = lfac_k - p1 + sum(p2 % log(p3)) + p4 * log(p5);
+      }
+
+      t_ind += 1;
+      y_ind += R;
+      p_ind += J;
+    }
+
+    vec g(K);
+    for (int i=0; i<K; i++){
+      g(i) = exp(sum(mn.row(i)));
+      if(!fin(m,i)){
+        f(i) = 0;
+        g(i) = 0;
+      }
+    }
+
+    ll(m) = log(sum(f % g));
+  }
+
+  return(wrap(-sum(ll)));
+
+}

--- a/src/nll_gdistsamp.cpp
+++ b/src/nll_gdistsamp.cpp
@@ -92,10 +92,9 @@ SEXP nll_gdistsamp(SEXP beta_, SEXP mixture_, SEXP keyfun_, SEXP survey_,
   int R = y.size() / M;
   int J = R / T;
   
-  vec detParam(M*T);
+  vec det_param(M*T);
   if(keyfun != "uniform"){
-    detParam = exp( Xdet * beta.subvec((nLP+nPP),(nLP+nPP+nDP-1)) 
-                        + Xdet_offset);
+    det_param = exp( Xdet * beta.subvec((nLP+nPP),(nLP+nPP+nDP-1)) + Xdet_offset);
   }
   
   int K = k.size();
@@ -126,7 +125,7 @@ SEXP nll_gdistsamp(SEXP beta_, SEXP mixture_, SEXP keyfun_, SEXP survey_,
           p = ones(J); 
         } else if (keyfun == "halfnorm"){
           //detParam is sigma
-          p = p_halfnorm(detParam(t_ind), survey, db, w, a.row(m));
+          p = p_halfnorm(det_param(t_ind), survey, db, w, a.row(m));
         }
         //other keyfuns
 

--- a/src/nll_gdistsamp.h
+++ b/src/nll_gdistsamp.h
@@ -1,0 +1,13 @@
+#ifndef _unmarked_NLL_GDISTSAMP_H
+#define _unmarked_NLL_GDISTSAMP_H
+
+#include <RcppArmadillo.h>
+
+RcppExport SEXP nll_gdistsamp(SEXP beta_, SEXP mixture_, SEXP keyfun_,
+    SEXP Xlam_, SEXP Xlam_offset_, SEXP A_, SEXP Xphi_, SEXP Xphi_offset_, 
+    SEXP Xdet_, SEXP Xdet_offset_, SEXP db_, SEXP a_, SEXP u_, SEXP w_,
+    SEXP k_, SEXP lfac_k_, SEXP lfac_kmyt_, SEXP kmyt_, 
+    SEXP y_, SEXP naflag_, SEXP fin_, 
+    SEXP nP_, SEXP nLP_, SEXP nPP_, SEXP nDP_, SEXP nSP_, SEXP nOP_) ;
+
+#endif

--- a/src/nll_gdistsamp.h
+++ b/src/nll_gdistsamp.h
@@ -3,7 +3,7 @@
 
 #include <RcppArmadillo.h>
 
-RcppExport SEXP nll_gdistsamp(SEXP beta_, SEXP mixture_, SEXP keyfun_,
+RcppExport SEXP nll_gdistsamp(SEXP beta_, SEXP mixture_, SEXP keyfun_, SEXP survey_,
     SEXP Xlam_, SEXP Xlam_offset_, SEXP A_, SEXP Xphi_, SEXP Xphi_offset_, 
     SEXP Xdet_, SEXP Xdet_offset_, SEXP db_, SEXP a_, SEXP u_, SEXP w_,
     SEXP k_, SEXP lfac_k_, SEXP lfac_kmyt_, SEXP kmyt_, 

--- a/src/nll_gdistsamp.h
+++ b/src/nll_gdistsamp.h
@@ -1,6 +1,8 @@
 #ifndef _unmarked_NLL_GDISTSAMP_H
 #define _unmarked_NLL_GDISTSAMP_H
 
+#include "R_ext/Applic.h"
+#include "detfuns.h"
 #include <RcppArmadillo.h>
 
 RcppExport SEXP nll_gdistsamp(SEXP beta_, SEXP mixture_, SEXP keyfun_, SEXP survey_,
@@ -8,6 +10,6 @@ RcppExport SEXP nll_gdistsamp(SEXP beta_, SEXP mixture_, SEXP keyfun_, SEXP surv
     SEXP Xdet_, SEXP Xdet_offset_, SEXP db_, SEXP a_, SEXP u_, SEXP w_,
     SEXP k_, SEXP lfac_k_, SEXP lfac_kmyt_, SEXP kmyt_, 
     SEXP y_, SEXP naflag_, SEXP fin_, 
-    SEXP nP_, SEXP nLP_, SEXP nPP_, SEXP nDP_, SEXP nSP_, SEXP nOP_) ;
+    SEXP nP_, SEXP nLP_, SEXP nPP_, SEXP nDP_, SEXP nSP_, SEXP nOP_, SEXP rel_tol_) ;
 
 #endif


### PR DESCRIPTION
Supports all combinations of key function, sampling type, and mixture. I added a bunch of tests to try to cover as many of the combinations as possible.

A possible future CRAN issue is that there are now some C++ compiler warnings apparently as a result of some namespace overlaps between RcppArmadillo and R_ext (used for integration). It does ultimately compile fine though, at least on my computer, and R CMD check is clean.

@rbchan I also found a possible bug in the R engine when there are missing y values. Can you check the commit comment in the patch to see if you agree with the change I made?