### PR TITLE
Handle fixed parameters in pcountopen simulate and fitted

### DIFF
--- a/R/pcountOpen.R
+++ b/R/pcountOpen.R
@@ -254,7 +254,7 @@ umfit <- new("unmarkedFitPCO", fitType = "pcountOpen",
     call = match.call(), formula = formula, formlist = formlist, data = data,
     sitesRemoved=D$removed.sites, estimates = estimateList, AIC = fmAIC,
     opt = opt, negLogLike = fm$value, nllFun = nll, K = K, mixture = mixture,
-    dynamics = dynamics, immigration = immigration)
+    dynamics = dynamics, immigration = immigration, fix = fix)
 return(umfit)
 }
 

--- a/R/unmarkedFit.R
+++ b/R/unmarkedFit.R
@@ -48,7 +48,8 @@ setClass("unmarkedFitPCO",
         representation(
             formlist = "list",
             dynamics = "character",
-            immigration = "logical"),
+            immigration = "logical",
+            fix = "character"),
         contains = "unmarkedFitPCount")
 
 
@@ -1724,6 +1725,8 @@ setMethod("fitted", "unmarkedFitPCO",
 {
     dynamics <- object@dynamics
     mixture <- object@mixture
+    #To partially handle old saved model objects
+    fix <- tryCatch(object@fix, error=function(e) "none")
     immigration <- tryCatch(object@immigration, error=function(e) FALSE)
     data <- getData(object)
     D <- getDesign(data, object@formula, na.rm = na.rm)
@@ -1749,7 +1752,9 @@ setMethod("fitted", "unmarkedFitPCO",
         psi <- plogis(coef(object, type="psi"))
         lambda <- (1-psi)*lambda
     }
-    if(!identical(dynamics, "trend")) {
+    if (fix == 'omega'){
+      omega <- matrix(1, M, T-1)
+    } else if(!identical(dynamics, "trend")) {
         if(identical(dynamics, "ricker") || identical(dynamics, "gompertz"))
             omega <- matrix(exp(Xom %*% coef(object, 'omega') + Xom.offset),
                         M, T-1, byrow=TRUE)
@@ -1757,10 +1762,12 @@ setMethod("fitted", "unmarkedFitPCO",
             omega <- matrix(plogis(Xom %*% coef(object, 'omega') + Xom.offset),
                         M, T-1, byrow=TRUE)
     }
-    if(!identical(dynamics, "notrend"))
+    if(fix == "gamma"){
+        gamma <- matrix(0, M, T-1)
+    } else if(!identical(dynamics, "notrend")){
         gamma <- matrix(exp(Xgam %*% coef(object, 'gamma') + Xgam.offset),
                         M, T-1, byrow=TRUE)
-    else {
+    } else {
         if(identical(dynamics, "notrend"))
             gamma <- (1-omega)*lambda
         }
@@ -3004,7 +3011,8 @@ setMethod("simulate", "unmarkedFitPCO",
 {
     mix <- object@mixture
     dynamics <- object@dynamics
-    umf <- object@data
+    #To partially handle old saved model objects
+    fix <- tryCatch(object@fix, error=function(e) "none")
     immigration <- tryCatch(object@immigration, error=function(e) FALSE)
     D <- getDesign(umf, object@formula, na.rm = na.rm)
     Xlam <- D$Xlam; Xgam <- D$Xgam; Xom <- D$Xom; Xp <- D$Xp; Xiota <- D$Xiota
@@ -3025,12 +3033,17 @@ setMethod("simulate", "unmarkedFitPCO",
     if(is.null(Xiota.offset)) Xiota.offset <- rep(0, M*(T-1))
 
     lambda <- drop(exp(Xlam %*% coef(object, 'lambda') + Xlam.offset))
-    if(dynamics != "notrend" & !is.null(coef(object, 'gamma')))
+    if(fix == "gamma"){
+        gamma <- matrix(0, M, T-1)
+    } else if(dynamics != "notrend"){
         gamma <- matrix(exp(Xgam %*% coef(object, 'gamma') + Xgam.offset),
                         M, T-1, byrow=TRUE)
-    else
+    } else {
         gamma <- matrix(NA, M, T-1)
-    if(dynamics == "trend")
+    }
+    if (fix == "omega")
+        omega <- matrix(1, M, T-1)
+    else if(dynamics == "trend")
         omega <- matrix(-999, M, T-1) # placeholder
     else if(identical(dynamics, "ricker"))
         omega <- matrix(exp(Xom %*% coef(object, 'omega') + Xom.offset),

--- a/R/unmarkedFit.R
+++ b/R/unmarkedFit.R
@@ -3011,6 +3011,7 @@ setMethod("simulate", "unmarkedFitPCO",
 {
     mix <- object@mixture
     dynamics <- object@dynamics
+    umf <- object@data
     #To partially handle old saved model objects
     fix <- tryCatch(object@fix, error=function(e) "none")
     immigration <- tryCatch(object@immigration, error=function(e) FALSE)

--- a/inst/unitTests/runit.pcountOpen.R
+++ b/inst/unitTests/runit.pcountOpen.R
@@ -380,7 +380,7 @@ test.pcountOpen.dynamics <- function()
 }
 
 
-test.pcountOpen.fixGamma <- function() {
+test.pcountOpen.fix <- function() {
 
      set.seed(3)
      M <- 50
@@ -407,7 +407,14 @@ test.pcountOpen.fixGamma <- function() {
      
      m2 <- pcountOpen(~1, ~1, ~1, ~1, umf, K=20, fix='gamma')
      m2_sim <- simulate(m2)
-     checkEqualsNumeric(m2_sim[[1]][1,],c(8,6,3,6,8))
+     checkEqualsNumeric(m2_sim[[1]][1,],c(4,4,6,5,3))
+     m2_fit <- fitted(m2)
+     checkEqualsNumeric(m2_fit[1,1],3.448029,tol=1e-4)
 
+     m3 <- pcountOpen(~1, ~1, ~1, ~1, umf, K=20, fix='omega')
+     m3_sim <- simulate(m3)
+     checkEqualsNumeric(m3_sim[[1]][1,],c(2,1,3,5,4))
+     m3_fit <- fitted(m3)
+     checkEqualsNumeric(m3_fit[1,1], 2.481839, tol=1e-4)
 }
 


### PR DESCRIPTION
A more complete fix for #110 that correctly simulates data and generates fitted values when `fix='omega'` (omega=1) or `'gamma'` (gamma=0) in `pcountopen`. 

To implement this I had to add a new attribute to `pcountopen` fit objects ("fix") to keep track of which parameter was fixed - guessing from the coefficient names could be problematic. If the attribute is missing (i.e., a model fit from an older version of unmarked is imported) the fix value defaults to "none".