### PR TITLE
Use trapezoidal rule instead of Rdqags for approximating integrals

### DIFF
--- a/inst/unitTests/runit.distsamp.r
+++ b/inst/unitTests/runit.distsamp.r
@@ -124,7 +124,7 @@ test.distsamp.point.keyfuns <- function()
     checkEqualsNumeric(coef(fm.halfnorm),
                        coef(update(fm.halfnorm, engine="R")))
     checkEqualsNumeric(coef(fm.exp),
-                       coef(update(fm.exp, engine="R")))
+                       coef(update(fm.exp, engine="R")),tol=1e-5)
     checkEqualsNumeric(coef(fm.halfnorm),
                        coef(update(fm.halfnorm, engine="R")))
     checkEqualsNumeric(coef(fm.halfnorm),
@@ -152,5 +152,5 @@ test.distsamp.getP <- function() {
   checkEqualsNumeric(getP(unif)[1,], c(0.1111111, 0.3333333, 0.5555556), 
                      tol=1e-5)
   checkEqualsNumeric(getP(haz)[1,], c(0.04946332, 0.02826854, 0.01589744), 
-                     tol=1e-5)
+                     tol=1e-3)
 }

--- a/inst/unitTests/runit.gdistsamp.R
+++ b/inst/unitTests/runit.gdistsamp.R
@@ -395,5 +395,5 @@ test.gdistsamp.hazard <- function(){
 
     checkEqualsNumeric(coef(fm_R),c(0.70099,-0.23473,1.38888,
                                     1.40786,0.44896),tol=1e-4)
-    checkEqualsNumeric(coef(fm_R),coef(fm_C),tol=1e-4)
+    checkEqualsNumeric(coef(fm_R),coef(fm_C),tol=1e-3)
 }

--- a/src/detfuns.cpp
+++ b/src/detfuns.cpp
@@ -1,72 +1,15 @@
 #include "detfuns.h"
-#include <Rmath.h>
 
-// Half-normal detection function for line-transects
-void gxhn(double *x, int n, void *ex) {
-  double *v;
-  v = (double*)ex; // cast to double pointer
-  double sigma = v[0];
-  for(int i=0; i<n; i++) {
-    x[i] = exp(-x[i]*x[i] / (2*sigma*sigma));
+//Integrate with trapezoidal rule
+double trap_rule(IntFunc &f, double a, double b){
+  
+  int n = 100;
+  double h = (b - a) / n;
+  
+  double int_sum = 0;
+  for(int i=1; i<n; i++){
+    int_sum += f(a + i*h);
   }
+
+  return( h/2 * (f(a) + 2*int_sum + f(b)) );
 }
-
-// Half-normal detection function for point-transects
-void grhn(double *x, int n, void *ex) {
-  double *v;
-  v = (double*)ex; // cast to double pointer
-  double sigma = v[0];
-  for(int i=0; i<n; i++) {
-    x[i] = exp(-x[i]*x[i] / (2*sigma*sigma)) * x[i];
-  }
-}
-
-
-
-// Negative exponential detection function for line-transects
-void gxexp(double *x, int n, void *ex) {
-  double *v;
-  v = (double*)ex; // cast to double pointer
-  double rate = v[0];
-  for(int i=0; i<n; i++) {
-    x[i] = exp(-x[i] / rate);
-  }
-}
-
-// Negative exponential detection function for point-transects
-void grexp(double *x, int n, void *ex) {
-  double *v;
-  v = (double*)ex; // cast to double pointer
-  double rate = v[0];
-  for(int i=0; i<n; i++) {
-    x[i] = exp(-x[i] / rate) * x[i];
-  }
-}
-
-
-
-// Hazard-rate detection function for line-transects
-void gxhaz(double *x, int n, void *ex) {
-  double *v;
-  v = (double*)ex; // cast to double pointer
-  double shape = v[0];
-  double scale = v[1];
-  for(int i=0; i<n; i++) {
-    x[i] = 1 - exp(-1*pow(x[i]/shape, -scale));
-  }
-}
-
-
-// Hazard-rate detection function for point-transects
-void grhaz(double *x, int n, void *ex) {
-  double *v;
-  v = (double*)ex; // cast to double pointer
-  double shape = v[0];
-  double scale = v[1];
-  for(int i=0; i<n; i++) {
-    x[i] = (1 - exp(-1*pow(x[i]/shape, -scale))) * x[i];
-  }
-}
-
-
-

--- a/src/detfuns.h
+++ b/src/detfuns.h
@@ -1,13 +1,57 @@
-
 #ifndef _UNMARKED_DETFUNS_H
 #define _UNMARKED_DETFUNS_H
 
-void grhn(double *x, int n, void *ex);
-void gxhn(double *x, int n, void *ex);
-void grexp(double *x, int n, void *ex);
-void gxexp(double *x, int n, void *ex);
-void grhaz(double *x, int n, void *ex);
-void gxhaz(double *x, int n, void *ex);
+#include <Rcpp.h>
 
+using namespace Rcpp;
+
+//Base class for functions to integrate
+class IntFunc {
+  public:
+    IntFunc() {}
+    
+    virtual double operator()(const double& x) const {
+      return(0);
+    }
+};
+
+//Negative exponential function
+class DetExp: public IntFunc {
+  private:
+    double rate;
+    int point;
+  public:
+    DetExp(double rate_, int point_) :
+      rate(rate_), point(point_) {}
+
+    double operator()(const double& x) const {
+      double pd_adjust = 1.0;
+      if(point){
+        pd_adjust = x;
+      }
+      return( std::exp( -x/rate) * pd_adjust);
+    }
+};
+
+//Hazard function
+class DetHaz: public IntFunc {
+  private:
+    double shape;
+    double scale;
+    int point;
+  public:
+    DetHaz(double shape_, double scale_, int point_) : 
+      shape(shape_), scale(scale_), point(point_) {}
+
+    double operator()(const double& x) const {
+      double pd_adjust = 1.0;
+      if(point){
+        pd_adjust = x;
+      }
+      return( (1-std::exp(-1 * pow(x/shape, -scale))) * pd_adjust);
+    }
+};
+
+double trap_rule(IntFunc &f, double a, double b) ;
 
 #endif

--- a/src/nll_distsamp.cpp
+++ b/src/nll_distsamp.cpp
@@ -1,5 +1,4 @@
 #include "nll_distsamp.h"
-#include "detfuns.h"
 
 
 SEXP nll_distsamp( SEXP y_, SEXP lam_, SEXP sig_, SEXP scale_, SEXP a_, SEXP u_, SEXP w_, SEXP db_, SEXP keyfun_, SEXP survey_, SEXP reltol_ ) {
@@ -33,26 +32,9 @@ SEXP nll_distsamp( SEXP y_, SEXP lam_, SEXP sig_, SEXP scale_, SEXP a_, SEXP u_,
       f0 = Rf_dexp(0.0, 1/sig[i], false);
     for(int j=0; j<J; j++) {
       double cp = 0.0;
-      //  void *ex;
-      double *ex;
-      ex = (double *) R_alloc(2, sizeof(double));
-      ex[0] = sig[i];
-      ex[1] = scale;
-
-      // Integration settings given to Rdqags
       double lower = db[j];
       double upper = db[j+1];
-      double epsrel = Rcpp::as<double>(reltol_);
-      double epsabs = epsrel;
-      int limit = 100;
-      int lenw = 400;
-      int last = 0;
-      int iwork[100];
-      double work[400];
-      double result = 0.0; //DOUBLE_XMIN;
-      double abserr = 0.0;
-      int neval = 0;
-      int ier=0;
+      double result = 0.0;
 
       if(keyfun=="uniform") {
 	cp = u(i,j);
@@ -61,44 +43,24 @@ SEXP nll_distsamp( SEXP y_, SEXP lam_, SEXP sig_, SEXP scale_, SEXP a_, SEXP u_,
 	  if(keyfun=="halfnorm") {
 	    result = sig[i]*sig[i]*(1-exp(-upper*upper/(2*sig[i]*sig[i])))-
 	      sig[i]*sig[i]*(1-exp(-lower*lower/(2*sig[i]*sig[i])));
-	    // Rdqags(grhn, ex, &lower, &upper, &epsabs, &epsrel, &result,
-	    // 	   &abserr, &neval, &ier, &limit, &lenw, &last, &iwork,
-	    // 	   &work);
 	  } else if(keyfun=="exp") {
-	    Rdqags(grexp, ex, &lower, &upper, &epsabs, &epsrel, &result,
-		   &abserr, &neval, &ier, &limit, &lenw, &last, iwork,
-		   work);
+      DetExp f(sig[i], 1);
+      result = trap_rule(f, lower, upper);
 	  } else if(keyfun=="hazard") {
-	    Rdqags(grhaz, ex, &lower, &upper, &epsabs, &epsrel, &result,
-		   &abserr, &neval, &ier, &limit, &lenw, &last, iwork,
-		   work);
-	  }
-	  if(ier > 0 && verbose) {
-	    Rf_warning("The integration was not successful.");
+      DetHaz f(sig[i], scale, 1);
+      result = trap_rule(f, lower, upper);
 	  }
 	  cp = result * M_2PI / a(i,j) * u(i,j); // M_2PI is 2*pi
 	} else if(survey=="line") {
 	  if(keyfun=="halfnorm") {
 	    result = (Rf_pnorm5(upper, 0.0, sig[i], true, false) -
 		      Rf_pnorm5(lower, 0.0, sig[i], true, false)) / f0;
-	    // Rdqags(gxhn, ex, &lower, &upper, &epsabs, &epsrel, &result,
-	    //     &abserr, &neval, &ier, &limit, &lenw, &last, &iwork,
-	    //	   &work);
 	  } else if(keyfun=="exp") {
 	    result = sig[i]*(1-exp(-upper/sig[i])) -
 	      sig[i]*(1-exp(-lower/sig[i]));
-	    // result = (Rf_pexp(upper, 1/sig[i], true, false) -
-	    // Rf_pexp(lower, 1/sig[i], true, false)) / f0;
-	    // Rdqags(gxexp, ex, &lower, &upper, &epsabs, &epsrel, &result,
-	    // 	   &abserr, &neval, &ier, &limit, &lenw, &last, &iwork,
-	    // 	   &work);
 	  } else if(keyfun=="hazard") {
-	    Rdqags(gxhaz, ex, &lower, &upper, &epsabs, &epsrel, &result,
-		   &abserr, &neval, &ier, &limit, &lenw, &last, iwork,
-		   work);
-	  }
-	  if(ier > 0 && verbose) {
-	    Rf_warning("Warning: the integration was not successful.");
+      DetHaz f(sig[i], scale, 0);
+      result = trap_rule(f, lower, upper);
 	  }
 	  cp = result / w[j] * u(i,j);
 	}

--- a/src/nll_distsamp.h
+++ b/src/nll_distsamp.h
@@ -1,10 +1,8 @@
 #ifndef _UNMARKED_NLL_DISTSAMP_H
 #define _UNMARKED_NLL_DISTSAMP_H
 
-#include "R_ext/Applic.h"
-
 #include <Rcpp.h>
-
+#include "detfuns.h"
 
 RcppExport SEXP nll_distsamp( SEXP y_, SEXP lam_, SEXP sig_, SEXP scale_, SEXP a_, SEXP u_, SEXP w_, SEXP db_, SEXP keyfun_, SEXP survey_, SEXP reltol_ ) ;
 

--- a/src/nll_gdistsamp.h
+++ b/src/nll_gdistsamp.h
@@ -1,9 +1,8 @@
 #ifndef _unmarked_NLL_GDISTSAMP_H
 #define _unmarked_NLL_GDISTSAMP_H
 
-#include "R_ext/Applic.h"
-#include "detfuns.h"
 #include <RcppArmadillo.h>
+#include "detfuns.h"
 
 RcppExport SEXP nll_gdistsamp(SEXP beta_, SEXP mixture_, SEXP keyfun_, SEXP survey_,
     SEXP Xlam_, SEXP Xlam_offset_, SEXP A_, SEXP Xphi_, SEXP Xphi_offset_, 


### PR DESCRIPTION
Addresses #134 by replacing Rdqags with a built-in trapezoidal rule function. It should be extensible to other integrals we need to approximate in the future. This is currently only used for negative exponential (point) and hazard (point and line) for both distsamp and gdistsamp, the other detection functions already used solved integrals in both the C and R code. 

Changing the integral approximation results in some slight differences in parameter estimates for some tests (on order of 1e-4), hence my adjustments to these tests.

No more compiler warnings, at least on my machine!