### PR TITLE
Add function to calculate VIFs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Collate: 'classes.R' 'unmarkedEstimate.R' 'mapInfo.R' 'unmarkedFrame.R'
     'multinomPois.R' 'occu.R' 'occuRN.R' 'occuMulti.R' 'pcount.R' 'gmultmix.R'
     'pcountOpen.R' 'gdistsamp.R' 'unmarkedFitList.R' 'unmarkedLinComb.R'
     'ranef.R' 'boot.R' 'occuFP.R' 'gpcount.R' 'occuPEN.R' 'pcount.spHDS.R'
-    'occuMS.R' 'unmarkedCrossVal.R' 'piFun.R'
+    'occuMS.R' 'unmarkedCrossVal.R' 'piFun.R' 'vif.R'
 LinkingTo: Rcpp, RcppArmadillo 
 SystemRequirements: GNU make
 URL: http://groups.google.com/group/unmarked,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -56,6 +56,6 @@ export(csvToUMF, formatLong, formatWide, formatMult, formatDistData)
 
 # Misc
 export(imputeMissing, gxhn, gxexp, gxhaz, dxhn, dxexp, dxhaz, drhn, drexp,
-    drhaz, grhn, grexp, grhaz, sight2perpdist, lambda2psi, SSE)
+    drhaz, grhn, grexp, grhaz, sight2perpdist, lambda2psi, SSE, vif)
 
 useDynLib("unmarked", .registration=TRUE)

--- a/R/vif.R
+++ b/R/vif.R
@@ -1,0 +1,35 @@
+#Variance inflation factors for unmarked models
+#Calculated using var-cov matrix as with car::vif()
+
+vif <- function(mod, type){
+
+  v <- vcov(mod, type)
+  type_options <- names(mod@estimates)
+  if(!type%in%type_options){
+    stop(paste("Possible types are",paste(type_options, collapse=', ')),
+        call.=FALSE) 
+  }
+  est <- mod@estimates[type]@estimates
+  labs <- names(est)
+  ints <- grep("(Intercept)", labs)
+  if(length(ints)>0){
+    v <- v[-ints,-ints]
+    labs <- labs[-ints]
+  } else{
+    stop("No intercept", call.=FALSE)
+  }
+  n.terms <- length(labs)
+  if (n.terms < 2) stop("model contains fewer than 2 terms", call.=FALSE)
+
+  R <- stats::cov2cor(v)
+  detR <- det(R)
+
+  result <- numeric(n.terms)
+  names(result) <- labs
+  for (i in 1:n.terms) {
+    result[i] <- det(as.matrix(R[i, i])) * 
+                    det(as.matrix(R[-i, -i])) / detR
+  }
+  result
+
+}

--- a/inst/unitTests/runit.vif.R
+++ b/inst/unitTests/runit.vif.R
@@ -1,0 +1,51 @@
+test.vif.occu <- function() {
+
+  set.seed(123)
+  data(frogs)
+  pferUMF <- unmarkedFrameOccu(pfer.bin)
+  siteCovs(pferUMF) <- data.frame(sitevar1 = rnorm(numSites(pferUMF)))
+  #Add some correlated covariates
+  obsvar2 = rnorm(numSites(pferUMF) * obsNum(pferUMF))
+  obsvar3 = rnorm(numSites(pferUMF) * obsNum(pferUMF),mean=obsvar2,sd=0.5)
+  obsCovs(pferUMF) <- data.frame(
+                        obsvar1 = rnorm(numSites(pferUMF) * obsNum(pferUMF)),
+                        obsvar2=obsvar2,obsvar3=obsvar3)
+     
+  fm <- occu(~ obsvar1+obsvar2+obsvar3 ~ 1, pferUMF)
+  
+  #No type provided
+  checkException(vif_vals <- vif(fm))
+
+  #Wrong type provided
+  checkException(vif_vals <- vif(fm, type='fake'))
+
+  #Not enough covs
+  checkException(vif_vals <- vif(fm, type='state'))
+
+  #Get values for det
+  vif_vals <- vif(fm, type='det')
+  checkEqualsNumeric(vif_vals, c(1.002240,4.49552,4.490039),tol=1e-4)
+  checkEquals(names(vif_vals),c('obsvar1','obsvar2','obsvar3'))
+
+  #Compare to typical way of calculating
+  set.seed(123)
+  vt <- lm(obsvar2~obsvar1+obsvar3,data=obsCovs(pferUMF))
+  vt_2 <- 1/(1-summary(vt)$r.squared)
+  checkEqualsNumeric(vif_vals[2],vt_2,tol=0.1)
+
+}
+
+test.vif.multinomPois <- function(){
+  
+  set.seed(123)
+  data(ovendata)
+  ovenFrame <- unmarkedFrameMPois(ovendata.list$data,
+  siteCovs=as.data.frame(scale(ovendata.list$covariates[,-1])),
+  type = "removal")
+  fm1 <- multinomPois(~ 1 ~ ufc + trba, ovenFrame)
+  
+  vif_vals <- vif(fm1, type='state')
+
+  checkEqualsNumeric(vif_vals, c(1.285886,1.285886), tol=1e-4)
+
+}

--- a/man/vif.Rd
+++ b/man/vif.Rd
@@ -1,0 +1,19 @@
+\name{vif}
+\alias{vif}
+\title{Compute Variance Inflation Factors for an unmarkedFit Object.}
+\description{
+Compute the variance inflation factors (VIFs) for covariates in one level of the 
+model (i.e., occupancy or detection). Calculation of VIFs follows the approach 
+of function \code{vif} in package \code{car}, using the correlation matrix of 
+fitted model parameters.
+}
+\usage{
+vif(mod, type)
+}
+\arguments{
+  \item{mod}{An unmarked fit object.}
+  \item{type}{Level of the model for which to calculate VIFs (for example,
+              \code{'state'})}
+}
+\value{
+A named vector of variance inflation factor values for each covariate.}


### PR DESCRIPTION
There's been a few questions about calculating variance inflation factors (VIFs) for `unmarked` models on the mailing list. It's fairly easy to do this manually but I figured we could do better. This adds a function to calculate variance inflation factors for parameters in one level of an unmarked model (e.g. `'det'` or `'state'`). I called the function `vif()` to emulate `car::vif()` which I think is the most widely used function for this in R, but I could see changing it to `VIF()`. 

The function subsets the var-covar matrix to a specific model level, converts it to a correlation matrix, and uses that to calculate VIFs the same way `car::vif()` does (see [here](https://github.com/cran/car/blob/764931db4ebe3e80853ff6453f077e045f564584/R/vif.R)). This results in slightly different estimates of VIFs from the alternative approach of fitting a linear model with one covariate as the response and the others as the predictors, e.g.:

```r
library(unmarked)
set.seed(123)
data(frogs)
pferUMF <- unmarkedFrameOccu(pfer.bin)
siteCovs(pferUMF) <- data.frame(sitevar1 = rnorm(numSites(pferUMF)))

#Add some correlated covariates
obsvar2 = rnorm(numSites(pferUMF) * obsNum(pferUMF))
obsvar3 = rnorm(numSites(pferUMF) * obsNum(pferUMF),mean=obsvar2,sd=0.5)
obsCovs(pferUMF) <- data.frame(
                      obsvar1 = rnorm(numSites(pferUMF) * obsNum(pferUMF)),
                      obsvar2=obsvar2,obsvar3=obsvar3)
     
fm <- occu(~ obsvar1+obsvar2+obsvar3 ~ 1, pferUMF) 

#Get values for det model
vif(fm, type='det')

##  obsvar1  obsvar2  obsvar3 
## 1.002240 4.494552 4.490039

#Compare to alternative way of calculating
vt <- lm(obsvar2~obsvar1+obsvar3,data=obsCovs(pferUMF))
1/(1-summary(vt)$r.squared)

## [1] 4.444054
```
I assume this is just because of different optimization approaches. Regardless, getting a super exact VIF value doesn't seem crucial to me since it's a rough diagnostic. Calculating VIFs the second way (with `lm`) would be an order of magnitude more complicated and would probably require separate methods for each unmarked fitting function, so I didn't really want to go that route.