### PR TITLE
cloglog link function option for occu()

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -36,7 +36,7 @@ exportClasses(unmarkedFit, unmarkedFitOccu, unmarkedFitOccuFP, unmarkedFitDS,
 
 # Methods
 exportMethods(backTransform, coef, confint, coordinates, fitted, getData,
-              getP, getFP, getB, getY, head, hessian, linearComb, mle,
+              getP, getFP, getB, getY, getN, head, hessian, linearComb, mle,
               modSel, nllFun, numSites, numY, obsCovs, obsNum, "obsCovs<-",
               obsToY, "obsToY<-", parboot, plot, hist, predict, profile,
               projection, residuals, sampleSize, SE, show, simulate, siteCovs,

--- a/R/occuPEN.R
+++ b/R/occuPEN.R
@@ -23,7 +23,7 @@ computeMPLElambda = function(formula, data, knownOcc = numeric(0), starts, metho
 
   LRparams = glm.fit(x=X,y=apply(y,1,max),family=binomial(),intercept=F,start=starts[1:nOP])
   naiveOcc = mean(LRparams$fitted.values)
-  occuOutMLE = occu(formula,data,knownOcc, starts,
+  occuOutMLE = occu(formula,data,knownOcc = knownOcc, starts = starts,
                  method = "BFGS", engine = c("C", "R"), se = TRUE)
   meanDet = mean((1+exp(-occuOutMLE[2]@estimates%*%t(V)))^-1)
   MPLElambda = sqrt(sum(diag(occuOutMLE[2]@covMat)))*(1-(1-meanDet)^(dim(y)[2]))*(1-naiveOcc) # what if there are different numbers of visits to different sites?
@@ -80,7 +80,7 @@ occuPEN_CV <- function(formula, data, knownOcc = numeric(0), starts,
           beta.p <- params[(nOP+1):nP]
           .Call("nll_occu",
                   yvec, X, V, beta.psi, beta.p, nd, knownOccLog, navec,
-                  X.offset, V.offset, 
+                  X.offset, V.offset, "logit", 
                   PACKAGE = "unmarked")
       }
   } else {

--- a/R/unmarkedFit.R
+++ b/R/unmarkedFit.R
@@ -2721,7 +2721,7 @@ setMethod("hist", "unmarkedFitDS", function(x, lwd=1, lty=1, ...) {
 setGeneric("getP", function(object, ...) standardGeneric("getP"))
 setGeneric("getFP", function(object, ...) standardGeneric("getFP"))
 setGeneric("getB", function(object, ...) standardGeneric("getB"))
-
+setGeneric("getN", function(object, ...) standardGeneric("getN"))
 
 setMethod("getP", "unmarkedFit", function(object, na.rm = TRUE)
 {
@@ -3202,7 +3202,27 @@ setMethod("getP", "unmarkedFitGPC",
     return(p)
 })
 
+setMethod("getN", "unmarkedFitOccu", function(object, newdata=NULL, 
+                                              appendData=FALSE, level=0.95)
+{
+  
+  il <- object@estimates@estimates$state@invlink
+  if(il!="cloglog"){
+    stop("Requires cloglog link function for psi")
+  }
+  
+  if(is.null(newdata)){
+    newdata <- getData(object) 
+  }
+  
+  object@estimates@estimates$state@invlink <- "exp"
+  object@estimates@estimates$state@invlinkGrad <- "exp"
+  pr <- predict(object, type='state', newdata=newdata, 
+                appendData=appendData, level=level)
 
+  names(pr)[1] <- "N"
+  pr
+})
 
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -62,6 +62,15 @@ identLink <- function(x) x
 
 identLinkGrad <- function(x) 1
 
+#Complimentary log log link
+cloglog <- function(x){
+  1-exp(-exp(x))
+}
+
+cloglog.grad <- function(x){
+  exp(-exp(x))
+}
+
 ## use logarithms to vectorize row-wise products
 ## this speeds things up a LOT (vs. apply(x,1,prod))
 rowProds <- function(x, na.rm = FALSE)

--- a/inst/unitTests/runit.occu.R
+++ b/inst/unitTests/runit.occu.R
@@ -205,4 +205,16 @@ test.occu.cloglog <- function() {
   
   #Check error if wrong link function
   checkException(occu(~ele+wind ~ele+forest, occ.frame, linkPsi="fake"))
+  
+  #Check predictions
+  pr <- predict(occ_test, 'state')
+  checkEqualsNumeric(pr$Predicted[1:3],c(0.2934,0.6651,0.3915),tol=1e-4)
+
+  #Check derived abundance estimates
+  n_est <- getN(occ_test)
+  checkEqualsNumeric(n_est$N[1:3], c(0.3473,1.0939,00.4968), tol=1e-4)
+  
+  #Check for error when link function isn't cloglog
+  logit_mod <- occu(~1~1, occ.frame, se=F)  
+  checkException(getN(logit_mod))
 }

--- a/man/getN-methods.Rd
+++ b/man/getN-methods.Rd
@@ -1,0 +1,18 @@
+\name{getN-methods}
+\docType{methods}
+\alias{getN}
+\alias{getN-methods}
+%\alias{getN,unmarkedFit-method}
+\alias{getN,unmarkedFitOccu-method}
+
+\title{Methods for Function getN in Package `unmarked'}
+\description{
+Methods for function \code{getN} in Package `unmarked'. These methods
+return derived abundance from models that support it.
+}
+\section{Methods}{
+\describe{
+%\item{object = "unmarkedFit"}{A fitted model object}
+\item{object = "unmarkedFitOccu"}{A fitted model object}
+}}
+\keyword{methods}

--- a/man/occu.Rd
+++ b/man/occu.Rd
@@ -4,8 +4,8 @@
 
 \title{Fit the MacKenzie et al. (2002) Occupancy Model}
 
-\usage{occu(formula, data, knownOcc=numeric(0), starts, method="BFGS",
-    se=TRUE, engine=c("C", "R"), ...)}
+\usage{occu(formula, data, knownOcc=numeric(0), linkPsi=c("logit", "cloglog"),
+            starts, method="BFGS", se=TRUE, engine=c("C", "R"), ...)}
 
 \arguments{
     \item{formula}{Double right-hand side formula describing covariates of
@@ -14,6 +14,10 @@
     \item{knownOcc}{Vector of sites that are known to be occupied. These
     should be supplied as row numbers of the y matrix, eg, c(3,8) if
     sites 3 and 8 were known to be occupied a priori.}
+    \item{linkPsi}{Link function for the occupancy model. Options are  
+      \code{"logit"} for the standard occupancy model or \code{"cloglog"} 
+      for the complimentary log-log link, which relates occupancy
+      to site-level abundance. See details.}
     \item{starts}{Vector of parameter starting values.}
     \item{method}{Optimization method used by \code{\link{optim}}.}
     \item{se}{Logical specifying whether or not to compute standard
@@ -42,15 +46,29 @@ The observation process is modeled as
 
 \deqn{y_{ij}|z_i \sim Bernoulli(z_i p_{ij})}{y_ij | z_i ~ Bernoulli(z_i  * p_ij)}
 
-Covariates of \eqn{\psi_i}{psi_i} and \eqn{p_{ij}}{p_ij} are modeled
+By default, covariates of \eqn{\psi_i}{psi_i} and \eqn{p_{ij}}{p_ij} are modeled
 using the logit link according to the \code{formula} argument.  The formula is a double right-hand sided formula
 like \code{~ detform ~ occform} where \code{detform} is a formula for the detection process and \code{occform} is a
 formula for the partially observed occupancy state.  See \link{formula} for details on constructing model formulae
-in \R.}
+in \R.
+
+When \code{linkPsi = "cloglog"}, the complimentary log-log link 
+function is used for \eqn{psi} instead of the logit link. The cloglog link
+relates occupancy probability to the intensity parameter of an underlying
+Poisson process (Kery and Royle 2016). Thus, if abundance at a site is 
+can be modeled as \eqn{N_i ~ Poisson(\lambda_i)}, where 
+\eqn{log(\lambda_i) = \alpha + \beta*x}, then presence/absence data at the 
+site can be modeled as \eqn{Z_i ~ Binomial(\psi_i)} where 
+\eqn{cloglog(\psi_i) = \alpha + \beta*x}. 
+
+}
 
 \value{unmarkedFitOccu object describing the model fit.}
 
 \references{
+
+Kery, Marc, and J. Andrew Royle. 2016. \emph{Applied Hierarchical Modeling in
+  Ecology}, Volume 1. Academic Press. 
 
 MacKenzie, D. I., J. D. Nichols, G. B. Lachman, S. Droege,
   J. Andrew Royle, and C. A. Langtimm. 2002. Estimating Site Occupancy Rates

--- a/src/init.c
+++ b/src/init.c
@@ -15,7 +15,7 @@ extern SEXP nll_gmultmix( SEXP betaR, SEXP mixtureR, SEXP pi_funR, SEXP XlamR, S
 extern SEXP nll_gdistsamp(SEXP beta_, SEXP mixture_, SEXP keyfun_, SEXP survey_, SEXP Xlam_, SEXP Xlam_offset_, SEXP A_, SEXP Xphi_, SEXP Xphi_offset_, SEXP Xdet_, SEXP Xdet_offset_, SEXP db_, SEXP a_, SEXP u_, SEXP w_, SEXP k_, SEXP lfac_k_, SEXP lfac_kmyt_, SEXP kmyt_, SEXP y_, SEXP naflag_, SEXP fin_, SEXP nP_, SEXP nLP_, SEXP nPP_, SEXP nDP_, SEXP nSP_, SEXP nOP_, SEXP rel_tol_) ;
 extern SEXP nll_gpcount( SEXP y_, SEXP Xlam_, SEXP Xphi_, SEXP Xp_, SEXP beta_lam_, SEXP beta_phi_, SEXP beta_p_, SEXP log_alpha_, SEXP Xlam_offset_, SEXP Xphi_offset_, SEXP Xp_offset_, SEXP M_, SEXP mixture_, SEXP numPrimary_ ) ;
 extern SEXP nll_multinomPois( SEXP betaR, SEXP pi_funR, SEXP XlamR, SEXP Xlam_offsetR, SEXP XdetR, SEXP Xdet_offsetR, SEXP yR, SEXP navecR, SEXP nPr, SEXP nAPr ) ;
-extern SEXP nll_occu( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_psiR, SEXP beta_pR, SEXP ndR, SEXP knownOccR, SEXP navecR, SEXP X_offsetR, SEXP V_offsetR );
+extern SEXP nll_occu( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_psiR, SEXP beta_pR, SEXP ndR, SEXP knownOccR, SEXP navecR, SEXP X_offsetR, SEXP V_offsetR, SEXP link_psiR);
 extern SEXP nll_occuPEN( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_psiR, SEXP beta_pR, SEXP ndR, SEXP knownOccR, SEXP navecR, SEXP X_offsetR, SEXP V_offsetR, SEXP penaltyR );
 extern SEXP nll_occuMulti( SEXP fStartR, SEXP fStopR, SEXP dmFr, SEXP dmOccR, SEXP betaR, SEXP dmDetR, SEXP dStartR, SEXP dStopR, SEXP yR, SEXP yStartR, SEXP yStopR, SEXP Iy0r, SEXP zR, SEXP fixed0r);
 extern SEXP nll_occuMS( SEXP beta_, SEXP y_, SEXP dm_state_, SEXP dm_phi_, SEXP dm_det_, SEXP sind_, SEXP pind_, SEXP dind_, SEXP prm_, SEXP S_, SEXP T_, SEXP J_, SEXP N_, SEXP naflag_, SEXP guide_);
@@ -32,7 +32,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"nll_gdistsamp",   (DL_FUNC) &nll_gdistsamp,   29},
     {"nll_gpcount",     (DL_FUNC) &nll_gpcount,     14},
     {"nll_multinomPois",(DL_FUNC) &nll_multinomPois,10},
-    {"nll_occu",        (DL_FUNC) &nll_occu,        10},
+    {"nll_occu",        (DL_FUNC) &nll_occu,        11},
     {"nll_occuPEN",     (DL_FUNC) &nll_occuPEN,     11},
     {"nll_occuMulti",   (DL_FUNC) &nll_occuMulti,   14},
     {"nll_occuMS",      (DL_FUNC) &nll_occuMS,      15},

--- a/src/nll_occu.cpp
+++ b/src/nll_occu.cpp
@@ -2,7 +2,7 @@
 
 using namespace Rcpp ;
 
-SEXP nll_occu( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_psiR, SEXP beta_pR, SEXP ndR, SEXP knownOccR, SEXP navecR, SEXP X_offsetR, SEXP V_offsetR ) {
+SEXP nll_occu( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_psiR, SEXP beta_pR, SEXP ndR, SEXP knownOccR, SEXP navecR, SEXP X_offsetR, SEXP V_offsetR, SEXP link_psiR ) {
   arma::icolvec y = as<arma::icolvec>(yR);
   arma::mat X = as<arma::mat>(Xr);
   arma::mat V = as<arma::mat>(Vr);
@@ -13,12 +13,24 @@ SEXP nll_occu( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_psiR, SEXP beta_pR, SEXP ndR
   Rcpp::LogicalVector navec(navecR);
   arma::colvec X_offset = as<arma::colvec>(X_offsetR);
   arma::colvec V_offset = as<arma::colvec>(V_offsetR);
+  std::string link_psi = as<std::string>(link_psiR);
+  
   int R = X.n_rows;
   int J = y.n_elem / R;
-  arma::colvec logit_psi = X*beta_psi + X_offset;
+  
+  //Calculate psi
+  arma::colvec psi_lp = X*beta_psi + X_offset;
+  arma::colvec psi(R);
+  if(link_psi == "cloglog"){
+    psi = 1 - exp(-exp(psi_lp));
+  } else { 
+    psi = 1.0/(1.0+exp(-psi_lp));
+  }
+  
+  //Calculate p
   arma::colvec logit_p = V*beta_p + V_offset;
-  arma::colvec psi = 1.0/(1.0+exp(-logit_psi));
   arma::colvec p = 1.0/(1.0+exp(-logit_p));
+  
   double ll=0.0;
   int k=0; // counter
   for(int i=0; i<R; i++) {

--- a/src/nll_occu.h
+++ b/src/nll_occu.h
@@ -3,6 +3,6 @@
 
 #include <RcppArmadillo.h>
 
-RcppExport SEXP nll_occu( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_psiR, SEXP beta_pR, SEXP ndR, SEXP knownOccR, SEXP navecR, SEXP X_offsetR, SEXP V_offsetR ) ;
+RcppExport SEXP nll_occu( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_psiR, SEXP beta_pR, SEXP ndR, SEXP knownOccR, SEXP navecR, SEXP X_offsetR, SEXP V_offsetR, SEXP link_psiR ) ;
 
 #endif


### PR DESCRIPTION
Adds option to use complimentary log-log link function in `occu` with a new argument `linkPsi="cloglog"` (defaults to logit). Also added a new helper function `getN` which will calculate predicted abundance for these models.

Based on Jonathan Cohen's post in the forums:
https://groups.google.com/forum/#!searchin/unmarked/cohen%7Csort:date/unmarked/Xlp_QT7COJE/sLwRMomIAAAJ