### PR TITLE
Fit time-to-detection occupancy models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Collate: 'classes.R' 'unmarkedEstimate.R' 'mapInfo.R' 'unmarkedFrame.R'
     'multinomPois.R' 'occu.R' 'occuRN.R' 'occuMulti.R' 'pcount.R' 'gmultmix.R'
     'pcountOpen.R' 'gdistsamp.R' 'unmarkedFitList.R' 'unmarkedLinComb.R'
     'ranef.R' 'boot.R' 'occuFP.R' 'gpcount.R' 'occuPEN.R' 'pcount.spHDS.R'
-    'occuMS.R' 'unmarkedCrossVal.R' 'piFun.R' 'vif.R'
+    'occuMS.R' 'occuTTD.R' 'unmarkedCrossVal.R' 'piFun.R' 'vif.R'
 LinkingTo: Rcpp, RcppArmadillo 
 SystemRequirements: GNU make
 URL: http://groups.google.com/group/unmarked,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -20,7 +20,7 @@ import(lattice, methods, parallel, Rcpp, reshape2, Matrix)
 # Fitting functions
 export(occu, occuFP, occuRN, pcount, pcountOpen, multinomPois, distsamp,
        colext, gmultmix, gdistsamp, gpcount, occuPEN, occuPEN_CV, occuMulti,
-       occuMS, computeMPLElambda, pcount.spHDS)
+       occuMS, computeMPLElambda, pcount.spHDS, occuTTD)
 export(removalPiFun, doublePiFun)
 
 # S4 classes

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -49,7 +49,7 @@ export(unmarkedEstimate, fitList, mapInfo, unmarkedFrame,
     unmarkedFrameOccu, unmarkedFrameOccuFP, unmarkedFramePCount, unmarkedFrameMPois,
     unmarkedFrameDS, unmarkedMultFrame, unmarkedFrameGMM,
     unmarkedFramePCO, unmarkedFrameGDS, unmarkedFrameGPC, unmarkedFrameOccuMulti,
-    unmarkedFrameOccuMS)
+    unmarkedFrameOccuMS, unmarkedFrameOccuTTD)
 
 # Formatting
 export(csvToUMF, formatLong, formatWide, formatMult, formatDistData)

--- a/R/boot.R
+++ b/R/boot.R
@@ -510,7 +510,12 @@ setMethod("nonparboot", "unmarkedFitOccuPEN_CV",
 })
 
 
-
+setMethod("nonparboot", "unmarkedFitOccuTTD",
+    function(object, B = 0, keepOldSamples = TRUE, ...)
+{
+    callNextMethod(object, B=B, keepOldSamples=keepOldSamples,
+                   bsType="site")
+})
 
 
 

--- a/R/occuTTD.R
+++ b/R/occuTTD.R
@@ -45,7 +45,9 @@ occuTTD <- function(psiformula=~1, gammaformula=~1, epsilonformula=~1,
   #Reformat data for likelihood
   yvec <- as.numeric(t(y))
   naflag <- as.numeric(is.na(yvec))
-  ymax <- as.numeric(t(data@surveyLength))
+  surveyLength <- data@surveyLength
+  if(length(removed>0)) surveyLength <- surveyLength[-removed,]
+  ymax <- as.numeric(t(surveyLength))
   delta <- as.numeric(yvec<ymax)
    
   #Organize parameters---------------------------------------------------------
@@ -56,6 +58,11 @@ occuTTD <- function(psiformula=~1, gammaformula=~1, epsilonformula=~1,
   gamParms <- NULL; nGP <- 0; col_inds <- c(0,0)
   epsParms <- NULL; nEP <- 0; ext_inds <- c(0,0)
   if(T>1){
+
+    #Remove final year from col/ext design matrices
+    X.gam <- as.matrix(X.gam[-seq(T,N*T,by=T),,drop=FALSE])
+    X.eps <- as.matrix(X.eps[-seq(T,N*T,by=T),,drop=FALSE])
+
     gamParms <- colnames(X.gam); nGP <- ncol(X.gam)
     epsParms <- colnames(X.eps); nEP <- ncol(X.eps)
     col_inds <- (nOP+1):(nOP+nGP)
@@ -163,11 +170,11 @@ occuTTD <- function(psiformula=~1, gammaformula=~1, epsilonformula=~1,
                           invlink = invlink,
                           invlinkGrad = linkGrad)
   
-  det <- unmarkedEstimate(name = "Detection", short.name = "p",
+  det <- unmarkedEstimate(name = "Detection", short.name = "lam",
                           estimates = ests[det_inds],
                           covMat = as.matrix(covMat[det_inds,det_inds]),
-                          invlink = "logistic",
-                          invlinkGrad = "logistic.grad")
+                          invlink = "exp",
+                          invlinkGrad = "exp")
 
   if(T>1){
     col <- unmarkedEstimate(name = "Colonization", short.name = "col",

--- a/R/occuTTD.R
+++ b/R/occuTTD.R
@@ -81,7 +81,7 @@ occuTTD <- function(psiformula=~1, gammaformula=~1, epsilonformula=~1,
     #Get occupancy and detection parameters 
     psi <- linkFunc(W %*% params[psi_inds])
     psi <- cbind(1-psi, psi)
-    lam <- 1/exp(V %*% params[det_inds])
+    lam <- exp(V %*% params[det_inds])
     
     #Simplified version of Garrard et al. 2013 eqn 5
     #Extended to Weibull
@@ -138,7 +138,7 @@ occuTTD <- function(psiformula=~1, gammaformula=~1, epsilonformula=~1,
           params, yvec, delta, W, V, X.gam, X.eps,
           range(psi_inds)-1, range(det_inds)-1,
           range(col_inds)-1, range(ext_inds)-1,
-          linkPsi, ttdDist, N, R, T, J, naflag,
+          linkPsi, ttdDist, N, T, J, naflag,
           PACKAGE = "unmarked")
   }
   

--- a/R/occuTTD.R
+++ b/R/occuTTD.R
@@ -53,8 +53,8 @@ occuTTD <- function(psiformula=~1, gammaformula=~1, epsilonformula=~1,
   occParms <- colnames(W); nOP <- ncol(W)
   psi_inds <- 1:nOP
   
-  gamParms <- NULL; nGP <- 0
-  epsParms <- NULL; nEP <- 0
+  gamParms <- NULL; nGP <- 0; col_inds <- c(0,0)
+  epsParms <- NULL; nEP <- 0; ext_inds <- c(0,0)
   if(T>1){
     gamParms <- colnames(X.gam); nGP <- ncol(X.gam)
     epsParms <- colnames(X.eps); nEP <- ncol(X.eps)
@@ -127,10 +127,16 @@ occuTTD <- function(psiformula=~1, gammaformula=~1, epsilonformula=~1,
   }
 
   nll_C <- function(params){
-    return(0)
+    .Call("nll_occuTTD",
+          params, yvec, delta, W, V, X.gam, X.eps,
+          range(psi_inds)-1, range(det_inds)-1,
+          range(col_inds)-1, range(ext_inds)-1,
+          linkPsi, ttdDist, N, R, T, J, naflag,
+          PACKAGE = "unmarked")
   }
-
-  nll <- nll_R
+  
+  nll <- nll_C
+  if(engine == "R") nll <- nll_R
   
   #Run optim()-----------------------------------------------------------------
   if(!missing(starts) && length(starts) != nP)

--- a/R/occuTTD.R
+++ b/R/occuTTD.R
@@ -1,0 +1,207 @@
+
+#  Fit the time-to-detection model of Garrard et al. 2008, 2013
+#  with dynamic extension
+
+occuTTD <- function(psiformula=~1, gammaformula=~1, epsilonformula=~1, 
+                    detformula=~1, data,  ttdDist=c('exp','weibull'), 
+                    linkPsi = c("logit", "cloglog"), starts, method = "BFGS", 
+                    se = TRUE, engine = c("C", "R"), ...) {
+    
+  #Check arguments-------------------------------------------------------------
+  if(!is(data, "unmarkedFrameOccuTTD")){
+    stop("Data is not an unmarkedFrameOccuTTD object.")
+  }
+
+  engine <- match.arg(engine, c("C", "R"))
+  ttdDist <- match.arg(ttdDist, c("exp","weibull"))
+  linkPsi <- match.arg(linkPsi, c("logit","cloglog"))
+    
+  formula <- list(psiformula, gammaformula, epsilonformula, detformula)
+  formula <- as.formula(paste(unlist(formula),collapse=" "))
+
+  #Psi link function 
+  linkFunc <- plogis
+  invlink <- "logistic"
+  linkGrad <- "logistic.grad"
+  if(linkPsi == "cloglog"){
+    linkFunc <- cloglog
+    invlink <- "cloglog"
+    linkGrad <- "cloglog.grad"
+  }
+
+  #Process input data----------------------------------------------------------
+  designMats <- getDesign(data, formula)
+  #V = detection; W = occupancy
+  V <- designMats$V; W <- designMats$W
+  X.gam <- designMats$X.gam; X.eps <- designMats$X.eps
+  y <- designMats$y
+  removed <- designMats$removed.sites
+
+  N <- nrow(y)
+  R <- ncol(y)
+  T <- data@numPrimary
+  J <- R / T
+
+  #Reformat data for likelihood
+  yvec <- as.numeric(t(y))
+  naflag <- as.numeric(is.na(yvec))
+  ymax <- as.numeric(t(data@surveyLength))
+  delta <- as.numeric(yvec<ymax)
+   
+  #Organize parameters---------------------------------------------------------
+  detParms <- colnames(V); nDP <- ncol(V)
+  occParms <- colnames(W); nOP <- ncol(W)
+  psi_inds <- 1:nOP
+  
+  gamParms <- NULL; nGP <- 0
+  epsParms <- NULL; nEP <- 0
+  if(T>1){
+    gamParms <- colnames(X.gam); nGP <- ncol(X.gam)
+    epsParms <- colnames(X.eps); nEP <- ncol(X.eps)
+    col_inds <- (nOP+1):(nOP+nGP)
+    ext_inds <- (nOP+nGP+1):(nOP+nGP+nEP)
+  }
+  det_inds <- (nOP+nGP+nEP+1):(nOP+nGP+nEP+nDP)
+
+  parms <- c(occParms,gamParms,epsParms,detParms)
+  if(ttdDist == "weibull") parms <- c(parms, "k")
+  nP <- length(parms)
+
+  #Likelihood functions--------------------------------------------------------
+
+  nll_R <- function(params){
+    
+    #Get occupancy and detection parameters 
+    psi <- linkFunc(W %*% params[psi_inds])
+    psi <- cbind(1-psi, psi)
+    lam <- 1/exp(V %*% params[det_inds])
+    
+    #Simplified version of Garrard et al. 2013 eqn 5
+    #Extended to Weibull
+    if(ttdDist=='weibull'){
+      k <- exp(params[nP])
+      e_lamt <- ( k*lam*(lam*yvec)^(k-1) )^delta * exp(-1*(lam*yvec)^k)
+    } else {
+      e_lamt <- lam^delta * exp(-lam*yvec)  
+    }
+
+    #Get probability of y for each z state
+    get_Py <- function(e_lamt, delta){
+      sum_delt <- as.numeric(sum(delta, na.rm=T)>0)
+      c(1-sum_delt, prod(e_lamt[!is.na(e_lamt)]))
+    }
+    
+    #If dynamic, get col/ext probs and transition prob matrix
+    if(T>1){
+      col <- plogis(X.gam %*% params[col_inds])
+      ext <- plogis(X.eps %*% params[ext_inds])
+      phi <- cbind(1-col, col, ext, 1-ext)
+    }
+    
+    #Begin likelihood calculation
+    lik <- rep(NA,N)
+    ystart <- 1
+    phi_index <- 1
+    for (n in 1:N){
+      
+      phi_prod <- diag(2)     
+      #If dynamic, iterate through primary periods
+      if(T>1){
+        for (t in 1:(T-1)){
+          yend <- ystart+J-1
+          D_pt <- diag(get_Py(e_lamt[ystart:yend], delta[ystart:yend]))
+          phi_t <- matrix(phi[phi_index,],nrow=2, byrow=TRUE)
+          phi_prod <- phi_prod %*% ( D_pt %*% phi_t )
+          ystart <- ystart + J
+          phi_index <- phi_index + 1
+        }
+      } 
+
+      yend <- ystart+J-1
+      p_T <- get_Py(e_lamt[ystart:yend], delta[ystart:yend])
+      ystart <- ystart + J
+          
+      lik[n] <- psi[n,] %*% phi_prod %*% p_T
+    }
+    -sum(log(lik))
+  }
+
+  nll_C <- function(params){
+    return(0)
+  }
+
+  nll <- nll_R
+  
+  #Run optim()-----------------------------------------------------------------
+  if(!missing(starts) && length(starts) != nP)
+      stop(paste("The number of starting values should be", nP))
+  if(missing(starts)) starts <- rep(0, nP)
+
+  fm <- optim(starts, nll, method = method, hessian = se, ...)
+  if(se) {
+    tryCatch(covMat <- solve(fm$hessian),
+      error=function(x) stop(simpleError(paste("Hessian is singular.",
+        "Try providing starting values or using fewer covariates."))))
+  } else {
+      covMat <- matrix(NA, nP, nP)
+  }
+
+  #Build output object---------------------------------------------------------
+  ests <- fm$par
+  fmAIC <- 2 * fm$value + 2 * nP #+ 2*nP*(nP + 1)/(M - nP - 1)
+  names(ests) <- parms
+
+  psi <- unmarkedEstimate(name = "Occupancy", short.name = "psi",
+                          estimates = ests[psi_inds],
+                          covMat = as.matrix(covMat[psi_inds,psi_inds]),
+                          invlink = invlink,
+                          invlinkGrad = linkGrad)
+  
+  det <- unmarkedEstimate(name = "Detection", short.name = "p",
+                          estimates = ests[det_inds],
+                          covMat = as.matrix(covMat[det_inds,det_inds]),
+                          invlink = "logistic",
+                          invlinkGrad = "logistic.grad")
+
+  if(T>1){
+    col <- unmarkedEstimate(name = "Colonization", short.name = "col",
+                          estimates = ests[col_inds],
+                          covMat = as.matrix(covMat[col_inds,col_inds]),
+                          invlink = "logistic",
+                          invlinkGrad = "logistic.grad")
+
+    ext <- unmarkedEstimate(name = "Extinction", short.name = "ext",
+                          estimates = ests[ext_inds],
+                          covMat = as.matrix(covMat[ext_inds,ext_inds]),
+                          invlink = "logistic",
+                          invlinkGrad = "logistic.grad")
+
+
+    estimateList <- unmarkedEstimateList(list(psi = psi, col = col,
+                                            ext = ext, det=det))
+  } else {
+    estimateList <- unmarkedEstimateList(list(psi = psi, det=det))
+  }
+ 
+  #Add Weibull shape parameter if necessary
+  if(ttdDist=="weibull"){
+    estimateList@estimates$shape <- unmarkedEstimate(name = "Weibull shape",
+    short.name = "k", estimates = ests[nP],
+    covMat = as.matrix(covMat[nP, nP]), invlink = "exp",
+    invlinkGrad = "exp")
+  }
+
+  umfit <- new("unmarkedFitOccuTTD", fitType = "occuTTD",
+               call = match.call(),
+               formula = formula,
+               psiformula = psiformula,
+               gamformula = gammaformula,
+               epsformula = epsilonformula,
+               detformula = detformula,
+               data = data, sitesRemoved = removed,
+               estimates = estimateList,
+               AIC = fmAIC, opt = fm, negLogLike = fm$value,
+               nllFun = nll)
+
+  return(umfit)
+}

--- a/R/unmarkedEstimate.R
+++ b/R/unmarkedEstimate.R
@@ -127,7 +127,7 @@ setMethod("summary", signature(object = "unmarkedEstimate"),
     link <- switch(invlink,
                    exp = "log",
                    logistic = "logit",
-                   cloglog = "clogog")
+                   cloglog = "cloglog")
     cat(object@name, " (", link, "-scale)", ":\n", sep="")
     outDF <- data.frame(Estimate = ests, SE = SEs, z = Z, "P(>|z|)" = p,
                         check.names = FALSE)

--- a/R/unmarkedEstimate.R
+++ b/R/unmarkedEstimate.R
@@ -126,7 +126,8 @@ setMethod("summary", signature(object = "unmarkedEstimate"),
     invlink <- object@invlink
     link <- switch(invlink,
                    exp = "log",
-                   logistic = "logit")
+                   logistic = "logit",
+                   cloglog = "clogog")
     cat(object@name, " (", link, "-scale)", ":\n", sep="")
     outDF <- data.frame(Estimate = ests, SE = SEs, z = Z, "P(>|z|)" = p,
                         check.names = FALSE)

--- a/R/unmarkedFit.R
+++ b/R/unmarkedFit.R
@@ -98,6 +98,14 @@ setClass("unmarkedFitOccuMS",
             parameterization = "character"),
          contains = "unmarkedFit")
 
+setClass("unmarkedFitOccuTTD",
+    representation(
+        psiformula = "formula",
+        gamformula = "formula",
+        epsformula = "formula",
+        detformula = "formula"),
+    contains = "unmarkedFit")
+
 setClass("unmarkedFitMPois",
     contains = "unmarkedFit")
 

--- a/inst/unitTests/runit.occuTTD.R
+++ b/inst/unitTests/runit.occuTTD.R
@@ -1,0 +1,65 @@
+test.unmarkedFrameOccuTTD <- function() {
+
+  set.seed(123)
+  N <- 100
+  psi <- 0.4
+  lam <- 7
+  Tmax <- 10
+
+  z <- rbinom(N, 1, psi)
+  y <- rexp(N, 1/lam)
+  y[z==0] <- Tmax
+  y[y>Tmax] <- Tmax
+  
+  sc <- as.data.frame(matrix(rnorm(N*2),ncol=2))
+  oc <- as.data.frame(matrix(rnorm(N*2),ncol=2))
+
+  umf <- unmarkedFrameOccuTTD(y=y, surveyLength=Tmax, siteCovs=sc, obsCovs=oc)
+  
+  checkEqualsNumeric(getY(umf), y) 
+  checkEqualsNumeric(dim(getY(umf)), c(100,1))
+  checkEqualsNumeric(siteCovs(umf), sc)
+  checkEqualsNumeric(obsCovs(umf), oc)
+
+  checkEqualsNumeric(umf@numPrimary, 1)
+  checkEqualsNumeric(umf@surveyLength, matrix(Tmax, 100, 1))
+  checkEquals(class(umf)[1], "unmarkedFrameOccuTTD")
+  
+  hd <- head(umf)
+  checkEqualsNumeric(as(hd, 'data.frame'), as(umf, 'data.frame')[1:10,])
+  
+  umf_sub <- umf[c(1,3),]
+  checkEqualsNumeric(as(umf_sub, 'data.frame'), as(umf, 'data.frame')[c(1,3),])
+  
+  checkException(umf[,2])
+
+  sl_bad <- c(10,10)
+  checkException(unmarkedFrameOccuTTD(y, sl_bad))
+
+  ## Multiple observers
+  y <- cbind(y,y)
+  oc <- as.data.frame(matrix(rnorm(N*2*2),ncol=2))
+  tm <- cbind(rep(10,N),rep(5,N))
+  umf <- unmarkedFrameOccuTTD(y=y, surveyLength=tm, siteCovs=sc, obsCovs=oc)
+  
+  checkEqualsNumeric(getY(umf), y) 
+  checkEqualsNumeric(dim(getY(umf)), c(100,2))
+  checkEqualsNumeric(obsCovs(umf), oc)
+
+  checkEqualsNumeric(umf@numPrimary, 1)
+  checkEqualsNumeric(umf@surveyLength, tm)
+  checkException(umf[,2])
+
+  ## Multiple primary periods
+  umf <- unmarkedFrameOccuTTD(y=y, surveyLength=tm, siteCovs=sc, 
+                              yearlySiteCovs=oc, numPrimary=2)
+  
+  checkEqualsNumeric(yearlySiteCovs(umf), oc)
+  checkEqualsNumeric(umf@numPrimary, 2)
+  umf_sub <- umf[,2]
+  checkEqualsNumeric(getY(umf_sub), y[,2,drop=F])
+  
+  y <- rexp(N, 1/lam)
+  y <- cbind(y,y,y)
+  checkException(unmarkedFrameOccuTTD(y,Tmax,numPrimary=2))
+}

--- a/inst/unitTests/runit.occuTTD.R
+++ b/inst/unitTests/runit.occuTTD.R
@@ -63,3 +63,214 @@ test.unmarkedFrameOccuTTD <- function() {
   y <- cbind(y,y,y)
   checkException(unmarkedFrameOccuTTD(y,Tmax,numPrimary=2))
 }
+
+test.occuTTD.singleseason <- function(){
+
+  #One observer------------------------------------
+  set.seed(123)
+  N <- 500; J <- 1
+
+  #Simulate occupancy
+  scovs <- data.frame(elev=c(scale(runif(N, 0,100))),
+                          forest=runif(N,0,1),
+                          wind=runif(N,0,1))
+  beta_N <- c(-0.69, 0.71, -0.5)
+  lambda_N <- exp(cbind(1, scovs$elev, scovs$forest) %*% beta_N)
+  abun <- rpois(N, lambda_N)
+  z <- as.numeric(abun>0)
+
+  #Simulate detection
+  Tmax <- 10
+  beta_lam <- c(1.6, -0.2, 0.7)
+  rate <- exp(cbind(1, scovs$elev, scovs$wind) %*% beta_lam)
+  ttd <- rexp(N, 1/rate)
+  ttd[z==0] <- Tmax
+  ttd[ttd>Tmax] <- Tmax
+
+  #Build UMF
+  umf <- unmarkedFrameOccuTTD(y=ttd, surveyLength=Tmax, siteCovs=scovs)
+
+  fitR <- occuTTD(psiformula=~elev+forest, detformula=~elev+wind,
+                  data=umf, linkPsi='cloglog', ttdDist='exp',engine="R")
+
+  fitC <- occuTTD(psiformula=~elev+forest, detformula=~elev+wind,
+                  data=umf, linkPsi='cloglog', ttdDist='exp',engine="C")
+
+  checkEqualsNumeric(coef(fitR), coef(fitC))
+  checkEqualsNumeric(coef(fitC), c(-0.5619,0.8624,-0.7457,1.4808,
+                                   0.0211,0.4841), tol=1e-4)
+  checkEqualsNumeric(coef(fitC), c(beta_N, beta_lam), tol=0.3)
+
+  #Check weibull
+  fitR <- occuTTD(psiformula=~elev+forest, detformula=~elev+wind,
+                  data=umf, linkPsi='cloglog', 
+                  ttdDist='weibull',engine="R")
+
+  fitC <- occuTTD(psiformula=~elev+forest, detformula=~elev+wind,
+                  data=umf, linkPsi='cloglog', ttdDist='weibull',
+                  engine="C")
+
+  checkEqualsNumeric(coef(fitR), coef(fitC))
+  checkEqualsNumeric(coef(fitC), c(-0.6636,0.8476,-0.7021,1.2973,
+                                   0.04483,0.5944,0.0979), tol=1e-4)
+
+  #Check missing value handling
+  ttd_na <- ttd; ttd_na[1] <- NA
+  umf_na <- unmarkedFrameOccuTTD(y=ttd_na, Tmax, siteCovs=scovs)
+
+  fit_naR <- occuTTD(psiformula=~elev+forest, detformula=~elev+wind,
+                  data=umf_na, linkPsi='cloglog', 
+                  ttdDist='weibull',engine="R")
+
+  fit_naC <- occuTTD(psiformula=~elev+forest, detformula=~elev+wind,
+                  data=umf_na, linkPsi='cloglog', ttdDist='weibull',
+                  engine="C")
+
+  checkEqualsNumeric(coef(fit_naR), coef(fit_naC))
+  checkEqualsNumeric(fit_naC@AIC, 1225.399, tol=1e-4)
+  checkEqualsNumeric(fit_naC@sitesRemoved, 1)
+
+  #Two observers-----------------------------------
+  set.seed(123)
+  ocovs <- data.frame(obs=rep(c('A','B'),N))
+  Tmax <- 10
+  rateB <- exp(cbind(1, scovs$elev, scovs$wind) %*% beta_lam - 0.5)
+  rate2 <- as.numeric(t(cbind(rate, rateB)))
+  ttd <- rexp(N*2, 1/rate2)
+  ttd[z==0] <- Tmax
+  ttd[ttd>Tmax] <- Tmax
+  ttd <- matrix(ttd, nrow=N, byrow=T)
+
+  umf <- unmarkedFrameOccuTTD(y=ttd, surveyLength=Tmax, 
+                              siteCovs=scovs, obsCovs=ocovs)
+
+  fitR <- occuTTD(psiformula=~elev+forest, detformula=~elev+wind+obs,
+                  data=umf, linkPsi='cloglog', ttdDist='exp',engine="R")
+
+  fitC <- occuTTD(psiformula=~elev+forest, detformula=~elev+wind+obs,
+                  data=umf, linkPsi='cloglog', ttdDist='exp',engine="C")
+
+  checkEqualsNumeric(coef(fitR), coef(fitC), tol=1e-6)
+  
+  #Check site is retained when only one observation is missing
+  ttd_na <- ttd; ttd_na[1,1] <- NA
+  umf_na <- unmarkedFrameOccuTTD(y=ttd_na, Tmax, siteCovs=scovs,
+                                 obsCovs=ocovs)
+
+  fit_naR <- occuTTD(psiformula=~elev+forest, detformula=~elev+wind+obs,
+                  data=umf_na, linkPsi='cloglog', 
+                  ttdDist='weibull',engine="R")
+
+  fit_naC <- occuTTD(psiformula=~elev+forest, detformula=~elev+wind+obs,
+                  data=umf_na, linkPsi='cloglog', ttdDist='weibull',
+                  engine="C")
+
+  checkEqualsNumeric(coef(fit_naR), coef(fit_naC))
+  checkEqualsNumeric(fit_naC@sitesRemoved, numeric(0))
+  
+  #Check site is removed when both obs are NA
+  ttd_na <- ttd; ttd_na[1,] <- NA
+  umf_na <- unmarkedFrameOccuTTD(y=ttd_na, Tmax, siteCovs=scovs,
+                                 obsCovs=ocovs)
+
+  fit_naC <- occuTTD(psiformula=~elev+forest, detformula=~elev+wind+obs,
+                  data=umf_na, linkPsi='cloglog', 
+                  ttdDist='weibull',engine="C")
+  checkEqualsNumeric(fit_naC@sitesRemoved, 1)
+
+  #Check logit link
+  set.seed(123)
+  #Simulate occupancy
+  scovs <- data.frame(elev=c(scale(runif(N, 0,100))),
+                          forest=runif(N,0,1),
+                          wind=runif(N,0,1))
+  beta_N <- c(-0.69, 0.71, -0.5)
+  psi <- plogis(cbind(1, scovs$elev, scovs$forest) %*% beta_N)
+  z <- rbinom(N, 1, psi)
+
+  #Simulate detection
+  Tmax <- 10
+  beta_lam <- c(1.6, -0.2, 0.7)
+  rate <- exp(cbind(1, scovs$elev, scovs$wind) %*% beta_lam)
+  ttd <- rexp(N, 1/rate)
+  ttd[z==0] <- Tmax
+  ttd[ttd>Tmax] <- Tmax
+
+  umf <- unmarkedFrameOccuTTD(y=ttd, surveyLength=Tmax, siteCovs=scovs)
+
+  fitR <- occuTTD(psiformula=~elev+forest, detformula=~elev+wind,
+                  data=umf, linkPsi='logit', ttdDist='exp',engine="R")
+
+  fitC <- occuTTD(psiformula=~elev+forest, detformula=~elev+wind,
+                  data=umf, linkPsi='logit', ttdDist='exp',engine="C")
+
+  checkEqualsNumeric(coef(fitR), coef(fitC))
+  checkEqualsNumeric(coef(fitC), c(-0.4646,0.4718,-0.8557,
+                                   2.1669,-0.2539,-0.5139), tol=1e-4)
+
+}
+
+test.occuTTD.dynamic <- function(){
+
+  set.seed(123)
+  #Simulate initial occupancy
+  N <- 5000; J <- 1; T <- 2
+  scovs <- data.frame(elev=c(scale(runif(N, 0,100))),
+                          forest=runif(N,0,1),
+                          wind=runif(N,0,1))
+  beta_psi <- c(-0.69, 0.71, -0.5)
+  psi <- plogis(cbind(1, scovs$elev, scovs$forest) %*% beta_psi)
+  z <- matrix(NA, N, T)
+  z[,1] <- rbinom(N, 1, psi)
+
+  #Col/ext process
+  ysc <- data.frame(forest=rep(scovs$forest, each=T), 
+                    elev=rep(scovs$elev, each=T))
+  c_b0 <- -0.4; c_b1 <- 0.3
+  gam <- plogis(c_b0 + c_b1 * scovs$forest)
+
+  e_b0 <- -0.7; e_b1 <- 0.4
+  ext <- plogis(e_b0 + e_b1 * scovs$elev)
+
+  for (i in 1:N){
+    for (t in 1:(T-1)){
+      if(z[i,t]==1){
+        #ext
+        z[i,t+1] <- rbinom(1, 1, (1-ext[i]))
+      } else {
+        #col
+        z[i,t+1] <- rbinom(1,1, gam[i])
+      }
+    }
+  }
+
+  #Simulate detection
+  ocovs <- data.frame(obs=rep(c('A','B'),N*T))
+  Tmax <- 10
+  beta_lam <- c(1.6, -0.2, 0.7)
+  rate <- exp(cbind(1, scovs$elev, scovs$wind) %*% beta_lam)
+  rateB <- exp(cbind(1, scovs$elev, scovs$wind) %*% beta_lam - 0.5)
+  #Across seasons
+  rate2 <- as.numeric(t(cbind(rate, rateB, rate, rateB)))
+  ttd <- rexp(N*T*2, 1/rate2)
+  ttd <- matrix(ttd, nrow=N, byrow=T)
+  ttd[ttd>Tmax] <- Tmax
+  ttd[z[,1]==0,1:2] <- Tmax
+  ttd[z[,2]==0,3:4] <- Tmax
+  
+
+  umf <- unmarkedFrameOccuTTD(y = ttd, surveyLength = Tmax, 
+                          siteCovs = scovs, obsCovs=ocovs,
+                          yearlySiteCovs=ysc, numPrimary=2) 
+
+
+  fit <- occuTTD(psiformula=~elev+forest,detformula=~elev+wind+obs,
+                 gammaformula=~forest, epsilonformula=~elev, 
+                 data=umf,se=T,
+                 linkPsi='logit',ttdDist='exp',engine="C")
+
+  truth <- c(beta_psi, c_b0, c_b1, e_b0, e_b1, beta_lam, -0.5)
+  checkEqualsNumeric(coef(fit), truth, tol=0.1)
+  checkEqualsNumeric(fit@AIC, 45521.18,tol=1e-4)
+
+}

--- a/inst/unitTests/runit.occuTTD.R
+++ b/inst/unitTests/runit.occuTTD.R
@@ -152,6 +152,25 @@ test.occuTTD.singleseason <- function(){
 
   checkEqualsNumeric(coef(fitR), coef(fitC), tol=1e-6)
   
+  #Check predict
+  checkEqualsNumeric(as.numeric(predict(fitC, 'psi')[4,]), 
+                     c(0.9203, 0.06757,0.381416,0.9999), tol=1e-4)
+  checkEqualsNumeric(as.numeric(predict(fitC, 'det')[1,]),
+                     c(29.8237, 3.1514,24.2447,36.6866), tol=1e-4)
+  checkEqualsNumeric(as.numeric(predict(fitC, 'det', censor=T)[1,]),
+                     c(10, NA, NA, NA))
+  checkException(predict(fitC, 'col'))
+
+  #Check getP
+  gp <- getP(fitC)
+  checkEqualsNumeric(dim(gp), c(500,2))
+  checkEqualsNumeric(gp[1,], c(29.8237, 23.34352),tol=1e-4)
+
+  #Check fitted
+  checkException(fitted(fitC))
+  #Check residuals
+  checkException(residuals(fitC))
+
   #Check site is retained when only one observation is missing
   ttd_na <- ttd; ttd_na[1,1] <- NA
   umf_na <- unmarkedFrameOccuTTD(y=ttd_na, Tmax, siteCovs=scovs,

--- a/man/fitted-methods.Rd
+++ b/man/fitted-methods.Rd
@@ -8,6 +8,7 @@
 \alias{fitted,unmarkedFitOccuRN-method}
 \alias{fitted,unmarkedFitOccuMulti-method}
 \alias{fitted,unmarkedFitOccuMS-method}
+\alias{fitted,unmarkedFitOccuTTD-method}
 \alias{fitted,unmarkedFitPCount-method}
 \alias{fitted,unmarkedFitDS-method}
 \alias{fitted,unmarkedFitPCO-method}

--- a/man/getP-methods.Rd
+++ b/man/getP-methods.Rd
@@ -6,6 +6,7 @@
 \alias{getP,unmarkedFitOccuFP-method}
 \alias{getP,unmarkedFitOccuMulti-method}
 \alias{getP,unmarkedFitOccuMS-method}
+\alias{getP,unmarkedFitOccuTTD-method}
 \alias{getP,unmarkedFitDS-method}
 \alias{getP,unmarkedFitMPois-method}
 \alias{getP,unmarkedFitColExt-method}

--- a/man/nonparboot-methods.Rd
+++ b/man/nonparboot-methods.Rd
@@ -14,6 +14,7 @@
 \alias{nonparboot,unmarkedFitGDS-method}
 \alias{nonparboot,unmarkedFitGMM-method}
 \alias{nonparboot,unmarkedFitPCO-method}
+\alias{nonparboot,unmarkedFitOccuTTD-method}
 \title{ Nonparametric bootstrapping in unmarked }
 \description{
 Call \code{nonparboot} on an unmarkedFit to obtain non-parametric

--- a/man/occuTTD.Rd
+++ b/man/occuTTD.Rd
@@ -36,7 +36,60 @@
 
 \value{unmarkedFitOccuTTD object describing model fit.}
 
-\details{More later.}
+\details{
+
+Estimates site occupancy and detection probability from time-to-detection 
+(TTD) data, e.g. time to first detection of a particular bird species 
+during a point count or time-to-detection of a plant species while searching 
+a quadrat (Garrard et al. 2008). Time-to-detection can be modeled 
+as an exponential (\code{ttdDist="exp"}) or Weibull (\code{ttdDist="weibull"}) 
+random variable with rate parameter \eqn{\lambda} and, for the Weibull, 
+an additional shape parameter \eqn{k}. Note that \code{occuTTD} puts covariates
+on \eqn{\lambda} and not \eqn{1/\lambda}, i.e., the expected time between events.
+
+In the case where there are no detections before the maximum sample time at
+a site (\code{surveyLength}) is reached, we are not sure if the site is 
+unoccupied or if we just didn't wait long enough for a detection. We therefore 
+must censor the exponential or Weibull distribution at the maximum survey 
+length, \eqn{Tmax}. Thus, assuming true site occupancy at site \eqn{i} is 
+\eqn{z_i}, an exponential distribution for the TTD \eqn{y_i}, and that 
+\eqn{d_i = 1} indicates \eqn{y_i} is censored (Kery and Royle 2016): 
+
+\deqn{d_i = z_i * I(y_i > Tmax_i) + (1 - z_i)}
+
+and
+
+\deqn{y_i|z_i \sim Exponential(\lambda_i), d_i = 0}
+\deqn{y_i|z_i = Missing, d_i = 1}
+
+Because in \code{unmarked} values of \code{NA} are typically used to indicate 
+missing values that were a result of the sampling structure (e.g., lost data), 
+we indicate a censored \eqn{y_i} in \code{occuTTD} instead by setting 
+\eqn{y_i = Tmax_i} in the \code{y} matrix provided to 
+\code{\link{unmarkedFrameOccuTTD}}. You can provide either a single value of 
+\eqn{Tmax} to the \code{surveyLength} argument of \code{unmarkedFrameOccuTTD}, 
+or provide a matrix, potentially with a unique value of \eqn{Tmax} for each 
+value of \code{y}. Note that in the latter case the value of \code{y} that will 
+be interpreted by \code{occutTTD} as a censored observation (i.e., \eqn{Tmax}) 
+will differ between observations!
+
+Occupancy and detection can be estimated with only a single survey per site, 
+unlike a traditional occupancy model that requires at least two replicated 
+surveys at at least some sites. However, \code{occuTTD} also supports 
+multiple surveys per site using the model described in Garrard et al. (2013). 
+Furthermore, multi-season dynamic models are supported, using the same basic 
+structure as for standard occupancy models (see \code{\link{colext}}). 
+    
+When \code{linkPsi = "cloglog"}, the complimentary log-log link 
+function is used for \eqn{psi} instead of the logit link. The cloglog link
+relates occupancy probability to the intensity parameter of an underlying
+Poisson process (Kery and Royle 2016). Thus, if abundance at a site is 
+can be modeled as \eqn{N_i ~ Poisson(\lambda_i)}, where 
+\eqn{log(\lambda_i) = \alpha + \beta*x}, then presence/absence data at the 
+site can be modeled as \eqn{Z_i ~ Binomial(\psi_i)} where 
+\eqn{cloglog(\psi_i) = \alpha + \beta*x}. 
+
+}
 
 \references{
 
@@ -48,6 +101,8 @@ Garrard, G.E., McCarthy, M.A., Williams, N.S., Bekessy, S.A. and Wintle,
   B.A. 2013. A general model of detectability using species traits. Methods in 
   Ecology and Evolution 4: 45-52.
 
+Kery, Marc, and J. Andrew Royle. 2016. \emph{Applied Hierarchical Modeling in
+  Ecology}, Volume 1. Academic Press. 
 }
 
 \author{Ken Kellner \email{contact@kenkellner.com}}
@@ -58,6 +113,98 @@ Garrard, G.E., McCarthy, M.A., Williams, N.S., Bekessy, S.A. and Wintle,
 
 \examples{
 
-#More later
+\dontrun{
 
+### Single season model
+N <- 500; J <- 1
+
+#Simulate occupancy
+scovs <- data.frame(elev=c(scale(runif(N, 0,100))),
+                    forest=runif(N,0,1),
+                    wind=runif(N,0,1))
+
+beta_psi <- c(-0.69, 0.71, -0.5)
+psi <- plogis(cbind(1, scovs$elev, scovs$forest) %*% beta_psi)
+z <- rbinom(N, 1, psi)
+
+#Simulate detection
+Tmax <- 10 #Same survey length for all observations
+beta_lam <- c(-2, -0.2, 0.7)
+rate <- exp(cbind(1, scovs$elev, scovs$wind) %*% beta_lam)
+ttd <- rexp(N, rate)
+ttd[z==0] <- Tmax #Censor at unoccupied sites
+ttd[ttd>Tmax] <- Tmax #Censor when ttd was greater than survey length
+
+#Build unmarkedFrame
+umf <- unmarkedFrameOccuTTD(y=ttd, surveyLength=Tmax, siteCovs=scovs)
+
+#Fit model
+fit <- occuTTD(psiformula=~elev+forest, detformula=~elev+wind, data=umf)
+
+#Predict psi values
+predict(fit, type='psi', newdata=data.frame(elev=0.5, forest=1))
+
+### Dynamic model
+
+N <- 1000; J <- 2; T <- 2
+scovs <- data.frame(elev=c(scale(runif(N, 0,100))),
+                    forest=runif(N,0,1),
+                    wind=runif(N,0,1))
+
+beta_psi <- c(-0.69, 0.71, -0.5)
+psi <- plogis(cbind(1, scovs$elev, scovs$forest) %*% beta_psi)
+z <- matrix(NA, N, T)
+z[,1] <- rbinom(N, 1, psi)
+
+#Col/ext process
+ysc <- data.frame(forest=rep(scovs$forest, each=T), 
+                  elev=rep(scovs$elev, each=T))
+c_b0 <- -0.4; c_b1 <- 0.3
+gam <- plogis(c_b0 + c_b1 * scovs$forest)
+e_b0 <- -0.7; e_b1 <- 0.4
+ext <- plogis(e_b0 + e_b1 * scovs$elev)
+
+for (i in 1:N){
+  for (t in 1:(T-1)){
+    if(z[i,t]==1){
+      #ext
+      z[i,t+1] <- rbinom(1, 1, (1-ext[i]))
+    } else {
+      #col
+      z[i,t+1] <- rbinom(1,1, gam[i])
+    }
+  }
+}
+
+#Simulate detection
+ocovs <- data.frame(obs=rep(c('A','B'),N*T))
+Tmax <- 10
+beta_lam <- c(-2, -0.2, 0.7)
+rate <- exp(cbind(1, scovs$elev, scovs$wind) %*% beta_lam)
+#Add second observer at each site
+rateB <- exp(cbind(1, scovs$elev, scovs$wind) %*% beta_lam - 0.5)
+#Across seasons
+rate2 <- as.numeric(t(cbind(rate, rateB, rate, rateB)))
+ttd <- rexp(N*T*2, rate2)
+ttd <- matrix(ttd, nrow=N, byrow=T)
+ttd[ttd>Tmax] <- Tmax
+ttd[z[,1]==0,1:2] <- Tmax
+ttd[z[,2]==0,3:4] <- Tmax
+  
+umf <- unmarkedFrameOccuTTD(y = ttd, surveyLength = Tmax, 
+                            siteCovs = scovs, obsCovs=ocovs,
+                            yearlySiteCovs=ysc, numPrimary=2) 
+
+dim(umf@y) #num sites, (num surveys x num primary periods)
+
+fit <- occuTTD(psiformula=~elev+forest,detformula=~elev+wind+obs,
+               gammaformula=~forest, epsilonformula=~elev, 
+               data=umf,se=T,engine="C")
+
+truth <- c(beta_psi, c_b0, c_b1, e_b0, e_b1, beta_lam, -0.5)
+
+#Compare to truth
+cbind(coef(fit), truth)
+
+}
 }

--- a/man/occuTTD.Rd
+++ b/man/occuTTD.Rd
@@ -124,13 +124,13 @@ scovs <- data.frame(elev=c(scale(runif(N, 0,100))),
                     wind=runif(N,0,1))
 
 beta_psi <- c(-0.69, 0.71, -0.5)
-psi <- plogis(cbind(1, scovs$elev, scovs$forest) %*% beta_psi)
+psi <- plogis(cbind(1, scovs$elev, scovs$forest) \%*\% beta_psi)
 z <- rbinom(N, 1, psi)
 
 #Simulate detection
 Tmax <- 10 #Same survey length for all observations
 beta_lam <- c(-2, -0.2, 0.7)
-rate <- exp(cbind(1, scovs$elev, scovs$wind) %*% beta_lam)
+rate <- exp(cbind(1, scovs$elev, scovs$wind) \%*\% beta_lam)
 ttd <- rexp(N, rate)
 ttd[z==0] <- Tmax #Censor at unoccupied sites
 ttd[ttd>Tmax] <- Tmax #Censor when ttd was greater than survey length
@@ -152,7 +152,7 @@ scovs <- data.frame(elev=c(scale(runif(N, 0,100))),
                     wind=runif(N,0,1))
 
 beta_psi <- c(-0.69, 0.71, -0.5)
-psi <- plogis(cbind(1, scovs$elev, scovs$forest) %*% beta_psi)
+psi <- plogis(cbind(1, scovs$elev, scovs$forest) \%*\% beta_psi)
 z <- matrix(NA, N, T)
 z[,1] <- rbinom(N, 1, psi)
 
@@ -180,9 +180,9 @@ for (i in 1:N){
 ocovs <- data.frame(obs=rep(c('A','B'),N*T))
 Tmax <- 10
 beta_lam <- c(-2, -0.2, 0.7)
-rate <- exp(cbind(1, scovs$elev, scovs$wind) %*% beta_lam)
+rate <- exp(cbind(1, scovs$elev, scovs$wind) \%*\% beta_lam)
 #Add second observer at each site
-rateB <- exp(cbind(1, scovs$elev, scovs$wind) %*% beta_lam - 0.5)
+rateB <- exp(cbind(1, scovs$elev, scovs$wind) \%*\% beta_lam - 0.5)
 #Across seasons
 rate2 <- as.numeric(t(cbind(rate, rateB, rate, rateB)))
 ttd <- rexp(N*T*2, rate2)

--- a/man/occuTTD.Rd
+++ b/man/occuTTD.Rd
@@ -1,0 +1,63 @@
+\name{occuTTD}
+\alias{occuTTD}
+\title{Fit Single-Season and Dynamic Time-to-detection Occupancy Models}
+
+\usage{occuTTD(psiformula= ~1, gammaformula =  ~ 1, epsilonformula = ~ 1,
+    detformula = ~ 1, data, ttdDist = c("exp", "weibull"), 
+    linkPsi = c("logit", "cloglog"), starts, method="BFGS", se=TRUE, 
+    engine = c("C", "R"), ...)}
+
+\arguments{
+  \item{psiformula}{Right-hand sided formula for the initial probability of 
+    occupancy at each site.}
+  \item{gammaformula}{Right-hand sided formula for colonization probability.}
+  \item{epsilonformula}{Right-hand sided formula for extinction probability.}
+  \item{detformula}{Right-hand sided formula for mean time-to-detection.}
+  \item{data}{\code{unmarkedFrameOccuTTD} object that supplies the data 
+    (see \code{\link{unmarkedFrameOccuTTD}}).}
+  \item{ttdDist}{Distribution to use for time-to-detection; either
+    \code{"exp"} for the exponential, or \code{"weibull"} for the Weibull,
+    which adds an additional shape parameter \eqn{k}.}
+  \item{linkPsi}{Link function for the occupancy model. Options are  
+    \code{"logit"} for the standard occupancy model or \code{"cloglog"} 
+    for the complimentary log-log link, which relates occupancy
+    to site-level abundance.}
+  \item{starts}{optionally, initial values for parameters in the optimization.}
+  \item{method}{Optimization method used by \code{\link{optim}}.}
+  \item{se}{logical specifying whether or not to compute standard errors.}
+  \item{engine}{Either "C" or "R" to use fast C++ code or native R
+    code during the optimization.}
+  \item{\dots}{Additional arguments to optim, such as lower and upper bounds}
+}
+
+\description{Fit time-to-detection occupancy models of Garrard et al. 
+  (2008, 2013), either single-season or dynamic. Time-to-detection can be 
+  modeled with either an exponential or Weibull distribution.} 
+
+\value{unmarkedFitOccuTTD object describing model fit.}
+
+\details{More later.}
+
+\references{
+
+Garrard, G.E., Bekessy, S.A., McCarthy, M.A. and Wintle, B.A. 2008. When have 
+  we looked hard enough? A novel method for setting minimum survey effort 
+  protocols for flora surveys. Austral Ecology 33: 986-998.
+
+Garrard, G.E., McCarthy, M.A., Williams, N.S., Bekessy, S.A. and Wintle, 
+  B.A. 2013. A general model of detectability using species traits. Methods in 
+  Ecology and Evolution 4: 45-52.
+
+}
+
+\author{Ken Kellner \email{contact@kenkellner.com}}
+
+\seealso{\code{\link{unmarked}}, \code{\link{unmarkedFrameOccuTTD}}}
+
+\keyword{models}
+
+\examples{
+
+#More later
+
+}

--- a/man/predict-methods.Rd
+++ b/man/predict-methods.Rd
@@ -6,6 +6,7 @@
 \alias{predict,unmarkedFitOccuFP-method}
 \alias{predict,unmarkedFitOccuMulti-method}
 \alias{predict,unmarkedFitOccuMS-method}
+\alias{predict,unmarkedFitOccuTTD-method}
 \alias{predict,unmarkedFitPCount-method}
 \alias{predict,unmarkedFitColExt-method}
 \alias{predict,unmarkedFitGMM-method}

--- a/man/ranef-methods.Rd
+++ b/man/ranef-methods.Rd
@@ -16,6 +16,7 @@
 \alias{ranef,unmarkedFitGMMorGDS-method}
 \alias{ranef,unmarkedFitColExt-method}
 \alias{ranef,unmarkedFitPCO-method}
+\alias{ranef,unmarkedFitOccuTTD-method}
 \title{ Methods for Function \code{ranef} in Package \pkg{unmarked} }
 \description{
 Estimate posterior distributions of the random variables (latent

--- a/man/simulate-methods.Rd
+++ b/man/simulate-methods.Rd
@@ -9,6 +9,7 @@
 \alias{simulate,unmarkedFitOccuFP-method}
 \alias{simulate,unmarkedFitOccuMulti-method}
 \alias{simulate,unmarkedFitOccuMS-method}
+\alias{simulate,unmarkedFitOccuTTD-method}
 \alias{simulate,unmarkedFitPCount-method}
 \alias{simulate,unmarkedFitPCO-method}
 \alias{simulate,unmarkedFitGMM-method}

--- a/man/unmarkedFit-class.Rd
+++ b/man/unmarkedFit-class.Rd
@@ -42,6 +42,7 @@
 \alias{unmarkedFitGMM-class}
 \alias{unmarkedFitOccuMulti-class}
 \alias{unmarkedFitOccuMS-class}
+\alias{unmarkedFitOccuTTD-class}
 \alias{plot,profile,missing-method}
 \alias{show,unmarkedFit-method}
 \alias{summary,unmarkedFit-method}

--- a/man/unmarkedFit-class.Rd
+++ b/man/unmarkedFit-class.Rd
@@ -23,12 +23,14 @@
 \alias{residuals,unmarkedFitOccuFP-method}
 \alias{residuals,unmarkedFitOccuRN-method}
 \alias{residuals,unmarkedFitOccuMulti-method}
+\alias{residuals,unmarkedFitOccuTTD-method}
 \alias{update,unmarkedFit-method}
 \alias{update,unmarkedFitColExt-method}
 \alias{update,unmarkedFitPCO-method}
 \alias{update,unmarkedFitGMM-method}
 \alias{update,unmarkedFitOccuMulti-method}
 \alias{update,unmarkedFitOccuMS-method}
+\alias{update,unmarkedFitOccuTTD-method}
 \alias{sampleSize}
 \alias{sampleSize,unmarkedFit-method}
 \alias{unmarkedFitOccu-class}

--- a/man/unmarkedFrame-class.Rd
+++ b/man/unmarkedFrame-class.Rd
@@ -26,6 +26,7 @@
 \alias{obsToY<-}
 \alias{plot,unmarkedFrame,missing-method}
 \alias{plot,unmarkedFrameOccuMulti,missing-method}
+\alias{plot,unmarkedFrameOccuTTD,missing-method}
 \alias{powerAnalysis}
 \alias{powerAnalysis,formula,unmarkedFramePCount,numeric-method}
 \alias{projection,unmarkedFrame-method}
@@ -37,6 +38,7 @@
 \alias{unmarkedFrameOccu-class}
 \alias{unmarkedFrameOccuMulti-class}
 \alias{unmarkedFrameOccuMS-class}
+\alias{unmarkedFrameOccuTTD-class}
 \alias{unmarkedFrameMPois-class}
 \alias{unmarkedFramePCount-class}
 \alias{unmarkedFrameDS-class}
@@ -47,13 +49,17 @@
 \alias{unmarkedFrameGPC-class}
 \alias{show,unmarkedFrame-method}
 \alias{show,unmarkedFrameOccuMulti-method}
+\alias{show,unmarkedFrameOccuTTD-method}
 \alias{show,unmarkedMultFrame-method}
 \alias{summary,unmarkedFrame-method}
 \alias{summary,unmarkedFrameDS-method}
 \alias{summary,unmarkedMultFrame-method}
 \alias{summary,unmarkedFrameOccuMulti-method}
+\alias{summary,unmarkedFrameOccuTTD-method}
 \alias{[,unmarkedFrameOccuMulti,missing,numeric,missing-method}
+\alias{[,unmarkedFrameOccuTTD,missing,numeric,missing-method}
 \alias{[,unmarkedFrameOccuMS,numeric,missing,missing-method}
+\alias{[,unmarkedFrameOccuTTD,numeric,missing,missing-method}
 \alias{[,unmarkedFrameOccuMulti,numeric,missing,missing-method}
 
 \title{Class "unmarkedFrame" }

--- a/man/unmarkedFrameOccuTTD.Rd
+++ b/man/unmarkedFrameOccuTTD.Rd
@@ -1,0 +1,69 @@
+\name{unmarkedFrameOccuTTD}
+
+\alias{unmarkedFrameOccuTTD}
+
+\title{Create an unmarkedFrameOccuTTD object for the time-to-detection model
+       fit by occuTTD}
+
+\usage{
+  unmarkedFrameOccuTTD(y, surveyLength, siteCovs=NULL, obsCovs=NULL, 
+                           numPrimary=1, yearlySiteCovs=NULL)
+}
+
+\description{Organizes time-to-detection occupancy data along with covariates. 
+  This S4 class is required by the data argument of \code{\link{occuTTD}}}
+
+\arguments{
+    \item{y}{An MxR matrix of multi-state occupancy data for a species, 
+        where M is the number of sites and R is the maximum number of 
+        observations per site (across all primary periods and observations, if 
+        you have multi-season data). Values in \code{y} should be positive.}
+    \item{surveyLength}{The maximum length of a survey, in the same units as 
+        \code{y}. You can provide either a single value (if all surveys had
+        the same max length), or a matrix matching the dimensions of \code{y}
+        (if surveys had different max lengths).}
+    \item{siteCovs}{A \code{\link{data.frame}} of covariates that vary at the 
+        site level. This should have M rows and one column per covariate}
+    \item{obsCovs}{Either a named list of \code{\link{data.frame}}s of 
+        covariates that vary within sites, or a \code{\link{data.frame}} with 
+        MxR rows in the ordered by site-observation (if single-season) or 
+        site-primary period-observation (if multi-season).}
+    \item{numPrimary}{Number of primary time periods (e.g. seasons) for the 
+        dynamic or multi-season version of the model. There should be
+        an equal number of secondary periods in each primary period.}
+    \item{yearlySiteCovs}{A data frame with one column per covariate that varies 
+        among sites and primary periods (e.g. years). It should have MxT rows
+        where M is the number of sites and T the number of primary periods,
+        ordered by site-primary period. These covariates only used for dynamic 
+        (multi-season) models.}
+  
+}
+
+\details{
+    unmarkedFrameOccuTTD is the S4 class that holds data to be passed 
+    to the \code{\link{occuTTD}} model-fitting function.
+}
+
+\value{an object of class unmarkedFrameOccuTTD}
+
+\author{Ken Kellner \email{contact@kenkellner.com}}
+
+\examples{
+  
+  # For a single-season model
+  N <- 100 #Number of sites
+  psi <- 0.4 #Occupancy probability
+  lam <- 7 #Parameter for exponential distribution of time to detection
+  Tmax <- 10 #Maximum survey length
+
+  z <- rbinom(N, 1, psi) #Simulate occupancy
+  y <- rexp(N, 1/lam) #Simulate time to detection
+  y[z==0] <- Tmax
+  y[y>Tmax] <- Tmax
+  
+  sc <- as.data.frame(matrix(rnorm(N*2),ncol=2)) #Site covs
+  oc <- as.data.frame(matrix(rnorm(N*2),ncol=2)) #obs covs
+
+  umf <- unmarkedFrameOccuTTD(y=y, surveyLength=Tmax, siteCovs=sc, obsCovs=oc)
+  
+}

--- a/src/init.c
+++ b/src/init.c
@@ -19,6 +19,7 @@ extern SEXP nll_occu( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_psiR, SEXP beta_pR, S
 extern SEXP nll_occuPEN( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_psiR, SEXP beta_pR, SEXP ndR, SEXP knownOccR, SEXP navecR, SEXP X_offsetR, SEXP V_offsetR, SEXP penaltyR );
 extern SEXP nll_occuMulti( SEXP fStartR, SEXP fStopR, SEXP dmFr, SEXP dmOccR, SEXP betaR, SEXP dmDetR, SEXP dStartR, SEXP dStopR, SEXP yR, SEXP yStartR, SEXP yStopR, SEXP Iy0r, SEXP zR, SEXP fixed0r);
 extern SEXP nll_occuMS( SEXP beta_, SEXP y_, SEXP dm_state_, SEXP dm_phi_, SEXP dm_det_, SEXP sind_, SEXP pind_, SEXP dind_, SEXP prm_, SEXP S_, SEXP T_, SEXP J_, SEXP N_, SEXP naflag_, SEXP guide_);
+extern SEXP nll_occuTTD( SEXP beta_, SEXP y_, SEXP delta_, SEXP W_, SEXP V_, SEXP Xgam_, SEXP Xeps_, SEXP pind_, SEXP dind_, SEXP cind_, SEXP eind_, SEXP lpsi_, SEXP tdist_, SEXP N_, SEXP R_, SEXP T_, SEXP J_, SEXP naflag_);
 extern SEXP get_mlogit(SEXP lp_mat_, SEXP type_, SEXP S_, SEXP guide_);
 extern SEXP nll_occuRN( SEXP betaR, SEXP XlamR, SEXP Xlam_offsetR, SEXP XdetR, SEXP Xdet_offsetR, SEXP KR, SEXP yR, SEXP navecR, SEXP nPr, SEXP nOPr );
 extern SEXP nll_pcount( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_lamR, SEXP beta_pR, SEXP log_alphaR, SEXP X_offsetR, SEXP V_offsetR, SEXP naMatR, SEXP lkR, SEXP mixtureR ) ;
@@ -36,6 +37,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"nll_occuPEN",     (DL_FUNC) &nll_occuPEN,     11},
     {"nll_occuMulti",   (DL_FUNC) &nll_occuMulti,   14},
     {"nll_occuMS",      (DL_FUNC) &nll_occuMS,      15},
+    {"nll_occuTTD",     (DL_FUNC) &nll_occuTTD,     18},
     {"get_mlogit",      (DL_FUNC) &get_mlogit,       4},
     {"nll_occuRN",      (DL_FUNC) &nll_occuRN,      10},
     {"nll_pcount",      (DL_FUNC) &nll_pcount,      11},

--- a/src/init.c
+++ b/src/init.c
@@ -19,7 +19,7 @@ extern SEXP nll_occu( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_psiR, SEXP beta_pR, S
 extern SEXP nll_occuPEN( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_psiR, SEXP beta_pR, SEXP ndR, SEXP knownOccR, SEXP navecR, SEXP X_offsetR, SEXP V_offsetR, SEXP penaltyR );
 extern SEXP nll_occuMulti( SEXP fStartR, SEXP fStopR, SEXP dmFr, SEXP dmOccR, SEXP betaR, SEXP dmDetR, SEXP dStartR, SEXP dStopR, SEXP yR, SEXP yStartR, SEXP yStopR, SEXP Iy0r, SEXP zR, SEXP fixed0r);
 extern SEXP nll_occuMS( SEXP beta_, SEXP y_, SEXP dm_state_, SEXP dm_phi_, SEXP dm_det_, SEXP sind_, SEXP pind_, SEXP dind_, SEXP prm_, SEXP S_, SEXP T_, SEXP J_, SEXP N_, SEXP naflag_, SEXP guide_);
-extern SEXP nll_occuTTD( SEXP beta_, SEXP y_, SEXP delta_, SEXP W_, SEXP V_, SEXP Xgam_, SEXP Xeps_, SEXP pind_, SEXP dind_, SEXP cind_, SEXP eind_, SEXP lpsi_, SEXP tdist_, SEXP N_, SEXP R_, SEXP T_, SEXP J_, SEXP naflag_);
+extern SEXP nll_occuTTD( SEXP beta_, SEXP y_, SEXP delta_, SEXP W_, SEXP V_, SEXP Xgam_, SEXP Xeps_, SEXP pind_, SEXP dind_, SEXP cind_, SEXP eind_, SEXP lpsi_, SEXP tdist_, SEXP N_, SEXP T_, SEXP J_, SEXP naflag_);
 extern SEXP get_mlogit(SEXP lp_mat_, SEXP type_, SEXP S_, SEXP guide_);
 extern SEXP nll_occuRN( SEXP betaR, SEXP XlamR, SEXP Xlam_offsetR, SEXP XdetR, SEXP Xdet_offsetR, SEXP KR, SEXP yR, SEXP navecR, SEXP nPr, SEXP nOPr );
 extern SEXP nll_pcount( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_lamR, SEXP beta_pR, SEXP log_alphaR, SEXP X_offsetR, SEXP V_offsetR, SEXP naMatR, SEXP lkR, SEXP mixtureR ) ;
@@ -37,7 +37,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"nll_occuPEN",     (DL_FUNC) &nll_occuPEN,     11},
     {"nll_occuMulti",   (DL_FUNC) &nll_occuMulti,   14},
     {"nll_occuMS",      (DL_FUNC) &nll_occuMS,      15},
-    {"nll_occuTTD",     (DL_FUNC) &nll_occuTTD,     18},
+    {"nll_occuTTD",     (DL_FUNC) &nll_occuTTD,     17},
     {"get_mlogit",      (DL_FUNC) &get_mlogit,       4},
     {"nll_occuRN",      (DL_FUNC) &nll_occuRN,      10},
     {"nll_pcount",      (DL_FUNC) &nll_pcount,      11},

--- a/src/nll_occuTTD.cpp
+++ b/src/nll_occuTTD.cpp
@@ -1,0 +1,138 @@
+#include "nll_occuTTD.h"
+
+using namespace Rcpp;
+using namespace arma;
+
+//namespace {
+
+  vec get_Py(vec e_lamt, vec delta, vec naflag){
+    
+    //Remove NAs 
+    if(any(naflag)){
+      uvec ids = find(naflag != 1);
+      e_lamt = e_lamt.elem(ids);
+      delta = delta.elem(ids);
+    }
+    int sum_delt = any(delta);
+
+    vec out(2);
+    out(0) = 1 - sum_delt;
+    out(1) = prod(e_lamt);
+    return(out);
+  }
+
+  mat get_phi(rowvec phi_raw){
+    mat out(2,2);
+    out.row(0) = phi_raw.subvec(1,2);
+    out.row(1) = phi_raw.subvec(3,4);
+    return(out);
+  }
+
+//}
+
+SEXP nll_occuTTD( SEXP beta_, SEXP y_, SEXP delta_,
+    SEXP W_, SEXP V_, SEXP Xgam_, SEXP Xeps_, 
+    SEXP pind_, SEXP dind_, SEXP cind_, SEXP eind_, 
+    SEXP lpsi_, SEXP tdist_,
+    SEXP N_, SEXP R_, SEXP T_, SEXP J_,
+    SEXP naflag_){
+
+  //Inputs
+  const vec beta = as<vec>(beta_);
+  const vec y = as<vec>(y_);
+  const vec delta = as<vec>(delta_);
+  const vec naflag = as<vec>(naflag_);
+  const mat W = as<mat>(W_);
+  const mat V = as<mat>(V_);
+  const vec pind = as<vec>(pind_);
+  const vec dind = as<vec>(dind_);
+  const std::string lpsi = as<std::string>(lpsi_);
+  const std::string tdist = as<std::string>(tdist_);
+
+  int N = as<int>(N_);
+  int R = as<int>(R_);
+  int T = as<int>(T_);
+  int J = as<int>(J_);
+  int ys = y.size();
+
+  //Dynamic stuff
+  const mat Xgam = as<mat>(Xgam_);
+  const mat Xeps = as<mat>(Xeps_);
+  const vec cind = as<vec>(cind_);
+  const vec eind = as<vec>(eind_);
+
+  //Get psi values
+  colvec raw_psi = W * beta.subvec(pind(0), pind(1));
+  if(lpsi == "cloglog"){
+    raw_psi = 1 - exp(-exp(raw_psi));
+  } else {
+    raw_psi = 1 / (1 + exp(-raw_psi)); 
+  }
+  const mat psi = join_rows(1-raw_psi, raw_psi);
+
+  //Get lambda values
+  const vec lam = 1 / exp(V * beta.subvec(dind(0), dind(1)));
+  double k = 1;
+
+  vec e_lamt(ys); 
+  if(tdist == "weibull"){
+    k = exp(beta(beta.size() - 1));
+    for(int i=0; i<ys; i++){
+      e_lamt(i) = pow(k*lam(i)*pow(lam(i)*y(i),(k-1)),delta(i)) *
+          exp(-1*pow(lam(i)*y(i),k));
+    }
+  } else {
+    for(int i=0; i<ys; i++){
+      //exponential
+      e_lamt(i) = pow(lam(i),delta(i)) * exp(-lam(i)*y(i));
+    }
+  }
+
+  mat phi_raw(N, 4);
+  if(T > 1){
+    colvec col = Xgam * beta.subvec(cind(0), cind(1));
+    colvec ext = Xeps * beta.subvec(eind(0), eind(1));
+    ext = 1 / (1 + exp(-ext));
+    col = 1 / (1 + exp(-col));
+    phi_raw.col(0) = 1-col;
+    phi_raw.col(1) = col;
+    phi_raw.col(2) = ext;
+    phi_raw.col(3) = 1 - ext;
+  }
+
+  vec lik(N);
+  int ystart = 0;
+  int yend;
+  int phi_index = 0;
+  for (int n=0; n<N; n++){
+    
+    mat phi_prod = eye(2,2);
+    if(T > 1){
+      for(int t=0; t<(T-1); t++){
+        yend = ystart + J - 1;
+        vec Py_t = get_Py(e_lamt.subvec(ystart,yend),
+            delta.subvec(ystart,yend),
+            naflag.subvec(ystart,yend));
+        mat D_ph = diagmat(Py_t);
+        mat phi_t = get_phi(phi_raw.row(phi_index));
+        phi_prod = phi_prod * (D_ph * phi_t);
+        ystart += J;
+        phi_index += 1;
+      }
+    }
+
+    yend = ystart + J - 1;
+
+    vec Py_T = get_Py(e_lamt.subvec(ystart,yend),
+            delta.subvec(ystart,yend),
+            naflag.subvec(ystart,yend));
+    ystart += J;
+    
+    rowvec psi_phi = psi.row(n) * phi_prod;
+    lik(n) = dot(psi_phi, Py_T);
+
+  }
+
+  return(wrap(-sum(log(lik))));
+
+}

--- a/src/nll_occuTTD.cpp
+++ b/src/nll_occuTTD.cpp
@@ -34,7 +34,7 @@ SEXP nll_occuTTD( SEXP beta_, SEXP y_, SEXP delta_,
     SEXP W_, SEXP V_, SEXP Xgam_, SEXP Xeps_, 
     SEXP pind_, SEXP dind_, SEXP cind_, SEXP eind_, 
     SEXP lpsi_, SEXP tdist_,
-    SEXP N_, SEXP R_, SEXP T_, SEXP J_,
+    SEXP N_, SEXP T_, SEXP J_,
     SEXP naflag_){
 
   //Inputs
@@ -50,7 +50,6 @@ SEXP nll_occuTTD( SEXP beta_, SEXP y_, SEXP delta_,
   const std::string tdist = as<std::string>(tdist_);
 
   int N = as<int>(N_);
-  int R = as<int>(R_);
   int T = as<int>(T_);
   int J = as<int>(J_);
   int ys = y.size();
@@ -71,12 +70,11 @@ SEXP nll_occuTTD( SEXP beta_, SEXP y_, SEXP delta_,
   const mat psi = join_rows(1-raw_psi, raw_psi);
 
   //Get lambda values
-  const vec lam = 1 / exp(V * beta.subvec(dind(0), dind(1)));
-  double k = 1;
-
+  const vec lam = exp(V * beta.subvec(dind(0), dind(1)));
+  
   vec e_lamt(ys); 
   if(tdist == "weibull"){
-    k = exp(beta(beta.size() - 1));
+    double k = exp(beta(beta.size() - 1));
     for(int i=0; i<ys; i++){
       e_lamt(i) = pow(k*lam(i)*pow(lam(i)*y(i),(k-1)),delta(i)) *
           exp(-1*pow(lam(i)*y(i),k));

--- a/src/nll_occuTTD.cpp
+++ b/src/nll_occuTTD.cpp
@@ -23,8 +23,8 @@ using namespace arma;
 
   mat get_phi(rowvec phi_raw){
     mat out(2,2);
-    out.row(0) = phi_raw.subvec(1,2);
-    out.row(1) = phi_raw.subvec(3,4);
+    out.row(0) = phi_raw.subvec(0,1);
+    out.row(1) = phi_raw.subvec(2,3);
     return(out);
   }
 

--- a/src/nll_occuTTD.h
+++ b/src/nll_occuTTD.h
@@ -7,7 +7,7 @@ RcppExport SEXP nll_occuTTD( SEXP beta_, SEXP y_, SEXP delta_,
     SEXP W_, SEXP V_, SEXP Xgam_, SEXP Xeps_, 
     SEXP pind_, SEXP dind_, SEXP cind_, SEXP eind_, 
     SEXP lpsi_, SEXP tdist_,
-    SEXP N_, SEXP R_, SEXP T_, SEXP J_,
+    SEXP N_, SEXP T_, SEXP J_,
     SEXP naflag_) ;
 
 #endif

--- a/src/nll_occuTTD.h
+++ b/src/nll_occuTTD.h
@@ -1,0 +1,13 @@
+#ifndef _unmarked_NLL_OCCUTTD_H
+#define _unmarked_NLL_OCCUTTD_H
+
+#include <RcppArmadillo.h>
+
+RcppExport SEXP nll_occuTTD( SEXP beta_, SEXP y_, SEXP delta_,
+    SEXP W_, SEXP V_, SEXP Xgam_, SEXP Xeps_, 
+    SEXP pind_, SEXP dind_, SEXP cind_, SEXP eind_, 
+    SEXP lpsi_, SEXP tdist_,
+    SEXP N_, SEXP R_, SEXP T_, SEXP J_,
+    SEXP naflag_) ;
+
+#endif


### PR DESCRIPTION
Adds a new fitting function `occuTTD`, which fits time-to-detection occupancy models (inspired by Jonathan Cohen's recent post on the listserv, https://groups.google.com/forum/#!topic/unmarked/jAkuA0z_aGc).

You can fit models where there is a single survey per site, or multiple surveys per site (e.g., multiple observers). You can also fit dynamic models, with the same interface as `colext`. Time to detection can be modeled with an exponential or Weibull distribution.

Here's an example fitting the  TTD model in AHM, chapter 10:

```r
#AHM Example 10.12.1, page 616-617

library(AHMbook)
library(unmarked)

set.seed(1)
data <- simOccttd()

#Unmarked requires censored values = Tmax
y = data$ttd
y[is.na(y)] <- data$Tmax

sc <- data.frame(covB=data$covB)
oc <- data.frame(covA=data$covA)

umf <- unmarkedFrameOccuTTD(y=y, surveyLength=data$Tmax,
                            siteCovs=sc, obsCovs=oc) 

fit <- occuTTD(psiformula=~covB, detformula=~covA, data=umf)

fit

#For comparison of estimates to Bayesian model (pg 617), need to do some transforms
ests <- coef(fit)
ests[1] <- plogis(ests[1]); ests[3] <- exp(ests[3])
ests

#Plot predicted first detection time vs. covariate
rng <- range(data$covA)
rng_covA <- seq(rng[1],rng[2],length.out=100)
pr_ttd = 1/predict(fit, 'det', newdata=data.frame(covA=rng_covA))$Predicted
pr_ttd[pr_ttd > data$Tmax] <- data$Tmax
plot(rng_covA, pr_ttd, ylab="TTD", type='l', xlab="Covariate A")
points(data$covA, data$ttd,  col='red')
```