### PR TITLE
Fix broken example and some other `class(.) == *` situations

### DIFF
--- a/R/occuMS.R
+++ b/R/occuMS.R
@@ -5,7 +5,7 @@ occuMS <- function(detformulas, psiformulas, phiformulas=NULL, data,
 
   #Format input data-----------------------------------------------------------
   #Check data object
-  if(!class(data) == "unmarkedFrameOccuMS")
+  if(!inherits(data, "unmarkedFrameOccuMS"))
     stop("Data must be created with unmarkedFrameOccuMS()")
   
   #Check engine

--- a/R/occuMulti.R
+++ b/R/occuMulti.R
@@ -3,7 +3,7 @@ occuMulti <- function(detformulas, stateformulas,  data, maxOrder, starts,
   
   #Format input data-----------------------------------------------------------
   #Check data object
-  if(!class(data) == "unmarkedFrameOccuMulti")
+  if(!inherits(data, "unmarkedFrameOccuMulti"))
     stop("Data must be created with unmarkedFrameOccuMulti()")
  
   #Check engine

--- a/R/ranef.R
+++ b/R/ranef.R
@@ -388,7 +388,7 @@ setMethod("ranef", "unmarkedFitGMMorGDS",
 
     phi <- matrix(phi, nSites, byrow=TRUE)
 
-    if(identical(class(object)[1], "unmarkedFitGDS")) {
+    if(inherits(object, "unmarkedFitGDS")) {
         if(identical(object@output, "density")) {
             survey <- object@data@survey
             tlength <- object@data@tlength


### PR DESCRIPTION
Fixes #151 and removes a bunch of other instances of `class(.) == *` structure that CRAN discourages. Many still remain especially in `unmarkedFit.R` but are not as urgent. With this patch, the package gets a clean check against R-devel (as long as other patch related to `parboot` #153 is also applied).