### PR TITLE
Remove duplicated parboot code

### DIFF
--- a/R/boot.R
+++ b/R/boot.R
@@ -13,6 +13,22 @@ setClass("parboot",
                         t0 = "numeric",
                         t.star = "matrix"))
 
+setGeneric("replaceY", function(object, newY, replNA = TRUE, ...){
+           standardGeneric("replaceY")})
+setMethod("replaceY", "unmarkedFrame", function(object, newY, replNA=TRUE, ...){
+    if(replNA) is.na(newY) <- is.na(object@y)
+    object@y <- newY
+    object
+})
+setMethod("replaceY", "unmarkedFrameOccuMulti",
+          function(object, newY, replNA=TRUE, ...){
+      if(replNA){
+        newY <- mapply(function(x, y){ is.na(x) <- is.na(y); x},
+                       newY , object@ylist, SIMPLIFY=FALSE)
+      }
+      object@ylist <- newY
+      object
+})
 
 setMethod("parboot", "unmarkedFit",
     function(object, statistic=SSE, nsim=10, report, seed = NULL, parallel = TRUE, ncores, ...)
@@ -22,10 +38,7 @@ setMethod("parboot", "unmarkedFit",
     call <- match.call(call = sys.call(-1))
     formula <- object@formula
     umf <- getData(object)
-    y <- getY(umf)
-    if(class(object) %in% c("unmarkedFitOccu", "unmarkedFitOccuRN",
-        "unmarkedFitColExt"))
-            y <- truncateToBinary(y)
+    y <- getY(object)
     ests <- as.numeric(coef(object))
     t0 <- statistic(object, ...)
     lt0 <- length(t0)
@@ -46,15 +59,12 @@ setMethod("parboot", "unmarkedFit",
     
     if (no_par) {
       for(i in 1:nsim) {
-        y.sim <- simList[[i]]
-        is.na(y.sim) <- is.na(y)
-        simdata@y <- y.sim
+        simdata <- replaceY(simdata, simList[[i]])
         fit <- update(object, data=simdata, starts=ests, se=FALSE)
         t.star[i,] <- statistic(fit, ...)
         if(!missing(report)) {
           if (nsim > report && i %in% seq(report, nsim, by=report))
             cat(paste(round(t.star[(i-(report-1)):i,], 1), collapse=","), fill=TRUE)
-          #            flush.console()
         }
         out <- new("parboot", call=call, t0 = t0, t.star = t.star)
       }
@@ -67,15 +77,12 @@ setMethod("parboot", "unmarkedFit",
       fm.nms <- all.names(object@call)
       if (!any(grepl("~", fm.nms))) varList <- c(varList, fm.nms[2])
       ## Hack to get piFun for unmarkedFitGMM and unmarkedFitMPois
-      if (class(object) == "unmarkedFitGMM" | class(object) == "unmarkedFitMPois") 
-        varList <- c(varList, umf@piFun)
+      if(.hasSlot(umf, "piFun")) varList <- c(varList, umf@piFun)
       clusterExport(cl, varList, envir = environment())
       clusterEvalQ(cl, library(unmarked))
       clusterEvalQ(cl, list2env(dots))
       t.star.parallel <- parLapply(cl, 1:nsim, function(i) {
-        y.sim <- simList[[i]]
-        is.na(y.sim) <- is.na(y)
-        simdata@y <- y.sim
+        simdata <- replaceY(simdata, simList[[i]])
         fit <- update(object, data = simdata, starts = ests, se = FALSE)
         t.star <- statistic(fit, ...)
       })
@@ -87,66 +94,6 @@ setMethod("parboot", "unmarkedFit",
     return(out)
 })
 
-
-setMethod("parboot", "unmarkedFitOccuMulti",
-    function(object, statistic=SSE, nsim=10, report, seed = NULL, parallel = TRUE, ncores, ...)
-{
-
-  dots <- list(...)
-
-  SSE <- function(object){
-    r <- do.call(rbind, residuals(object))
-    return(c(SSE = sum(r^2, na.rm=T)))
-  }
-
-  statistic <- match.fun(statistic)
-  call <- object@call
-
-  ests <- as.numeric(coef(object))
-  t0 <- statistic(object, ...)
-  lt0 <- length(t0)
-
-  simdata <- object@data
-  if (!is.null(seed)) set.seed(seed)
-  simList <- simulate(object, nsim=nsim)
-
-  if(missing(ncores)) ncores <- availcores - 1
-  if(ncores > availcores) ncores <- availcores
-  no_par <- ncores < 2 || nsim < 100 || !parallel
-  
-  if(no_par){
-    t.star <- matrix(NA, nsim, lt0)
-    for (i in 1:nsim){
-      simdata@ylist <- simList[[i]]
-      fit <- update(object, data=simdata, starts=ests, se=F, silent=T)
-      t.star[i,] <- statistic(fit, ...)
-    }
-  } else {
-    if (!missing(report)) message("Running in parallel on ", ncores, " cores. Bootstrapped statistics not reported.")
-    cl <- makeCluster(ncores)
-    on.exit(stopCluster(cl))
-    varList <- c("simList", "object", "simdata", "ests", "statistic", "dots")
-    
-    clusterExport(cl, varList, envir = environment())
-    clusterEvalQ(cl, library(unmarked))
-    clusterEvalQ(cl, list2env(dots))
-    t.star.parallel <- parLapply(cl, 1:nsim, function(i) {
-      simdata@ylist <- simList[[i]]
-      fit <- update(object, data = simdata, starts = ests, se = F, silent=T)
-      statistic(fit, ...)
-    })
-    t.star <- matrix(unlist(t.star.parallel), nrow=length(t.star.parallel),
-                     byrow=T)
-  }
-  if(!is.null(names(t0))){
-    colnames(t.star) <- names(t0)
-  } else {
-    colnames(t.star) <- paste("t*", 1:lt0, sep="")
-  }
-  
-  new("parboot", call = call, t0 = t0, t.star = t.star)
-
-})
 
 setMethod("show", "parboot", function(object)
 {

--- a/R/unmarkedFit.R
+++ b/R/unmarkedFit.R
@@ -3366,7 +3366,20 @@ setMethod("getP", "unmarkedFitGPC",
     return(p)
 })
 
-
+#Y extractors for unmarkedFit objects
+setMethod("getY", "unmarkedFit", function(object) object@data@y)
+setMethod("getY", "unmarkedFitOccu", function(object) {
+            truncateToBinary(object@data@y)
+})
+setMethod("getY", "unmarkedFitOccuRN", function(object) {
+            truncateToBinary(object@data@y)
+})
+setMethod("getY", "unmarkedFitColExt", function(object) {
+            truncateToBinary(object@data@y)
+})
+setMethod("getY", "unmarkedFitOccuMulti", function(object) {
+            object@data@ylist
+})
 
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -683,15 +683,18 @@ sight2perpdist <- function(sightdist, sightangle)
     sightdist * sin(sightangle * pi / 180)
 }
 
+#Sum of squared errors method
+setGeneric("SSE", function(fit, ...) standardGeneric("SSE"))
 
-
-SSE <- function(fit)
-{
+setMethod("SSE", "unmarkedFit", function(fit, ...){
     sse <- sum(residuals(fit)^2, na.rm=TRUE)
     return(c(SSE=sse))
-}
+})
 
-
+setMethod("SSE", "unmarkedFitOccuMulti", function(fit, ...){
+    r <- do.call(rbind, residuals(fit))
+    return(c(SSE = sum(r^2, na.rm=T)))
+})
 
 # For pcountOpen. Calculate time intervals acknowledging gaps due to NAs
 # The first column indicates is time since first primary period + 1

--- a/man/SSE.Rd
+++ b/man/SSE.Rd
@@ -1,15 +1,19 @@
 \name{SSE}
 \alias{SSE}
+\alias{SSE-methods}
+\alias{SSE,unmarkedFit-method}
+\alias{SSE,unmarkedFitOccuMulti-method}
 \title{Compute Sum of Squared Residuals for a Model Fit.}
 \description{
 Compute the sum of squared residuals for an unmarked fit object.  This
 is useful for a \code{\link{parboot}}.
 }
 \usage{
-SSE(fit)
+SSE(fit, ...)
 }
 \arguments{
   \item{fit}{An unmarked fit object.}
+  \item{...}{Additional arguments to be passed to statistic}
 }
 \value{
 A numeric value for the models SSE.}

--- a/man/unmarkedFit-class.Rd
+++ b/man/unmarkedFit-class.Rd
@@ -57,6 +57,11 @@
 \alias{logLik,unmarkedFit-method}
 \alias{LRT}
 \alias{LRT,unmarkedFit,unmarkedFit-method}
+\alias{getY,unmarkedFit-method}
+\alias{getY,unmarkedFitOccu-method}
+\alias{getY,unmarkedFitColExt-method}
+\alias{getY,unmarkedFitOccuRN-method}
+\alias{getY,unmarkedFitOccuMulti-method}
 
 \title{Class "unmarkedFit" }
 \description{Contains fitted model information which can be manipulated or 


### PR DESCRIPTION
There was an unbound global variable (`availcore`) issue in checks after the last parboot patch #150. I reorganized the parboot code a bit to fix this and removed duplicated code to make future work easier.