### PR TITLE
Add maxOrder argument to unmarkedFrameOccuMulti, fixes #136

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: unmarked
-Version: 0.13-1.9000
-Date: 2020-01-01
+Version: 0.13-1.9001
+Date: 2020-01-17
 Type: Package
 Title: Models for Data from Unmarked Animals
 Author: Ian Fiske, Richard Chandler, David Miller, Andy Royle, Marc Kery, Jeff Hostetler, Rebecca Hutchinson, Adam Smith, Ken Kellner 

--- a/R/unmarkedFrame.R
+++ b/R/unmarkedFrame.R
@@ -224,30 +224,37 @@ unmarkedFrameOccuFP <- function(y, siteCovs = NULL, obsCovs = NULL, type, mapInf
 }
 
 unmarkedFrameOccuMulti <- function(y, siteCovs = NULL, obsCovs = NULL,
-                                   mapInfo = NULL)
+                                   maxOrder, mapInfo = NULL)
 {
-    ylist <- y
-    y <- ylist[[1]]
-    J <- ncol(y)
-    if(is.null(names(ylist)))
-       names(ylist) <- paste('sp',1:length(ylist),sep='')
-    
-    obsCovs <- covsToDF(obsCovs, "obsCovs", J, nrow(y))
-    
-    #f design matrix guide
-    S <- length(ylist)
-    z <- expand.grid(rep(list(1:0),S))[,S:1]
-    colnames(z) <- names(ylist)
-    fDesign <- model.matrix(as.formula(paste0("~.^",S,"-1")),z)
-    attr(fDesign,'assign') <- NULL
-    zinds <- apply(z,1,function(x) paste(x,collapse=''))
-    rownames(fDesign) <- paste('psi[',zinds,']',sep='')
-    colnames(fDesign) <- paste('f',1:ncol(fDesign),'[',
-                               colnames(fDesign),']',sep='')
-
-    umfmo <- new("unmarkedFrameOccuMulti", y=y, ylist = ylist, fDesign=fDesign,
-                 obsCovs = obsCovs, siteCovs = siteCovs, obsToY = diag(J))
-    return(umfmo)
+  ylist <- y
+  y <- ylist[[1]]
+  J <- ncol(y)
+  if(is.null(names(ylist)))
+    names(ylist) <- paste('sp',1:length(ylist),sep='')
+  
+  obsCovs <- covsToDF(obsCovs, "obsCovs", J, nrow(y))
+  
+  #f design matrix guide
+  S <- length(ylist)
+  z <- expand.grid(rep(list(1:0),S))[,S:1]
+  colnames(z) <- names(ylist)
+  
+  if(missing(maxOrder)) maxOrder <- S
+  if(maxOrder == 1){
+    fDesign <- as.matrix(z)
+  } else {
+    fDesign <- model.matrix(as.formula(paste0("~.^",maxOrder,"-1")),z)
+  }
+  
+  attr(fDesign,'assign') <- NULL
+  zinds <- apply(z,1,function(x) paste(x,collapse=''))
+  rownames(fDesign) <- paste('psi[',zinds,']',sep='')
+  colnames(fDesign) <- paste('f',1:ncol(fDesign),'[',
+                             colnames(fDesign),']',sep='')
+  
+  umfmo <- new("unmarkedFrameOccuMulti", y=y, ylist = ylist, fDesign=fDesign,
+               obsCovs = obsCovs, siteCovs = siteCovs, obsToY = diag(J))
+  return(umfmo)
 }
 
 

--- a/man/unmarkedFrameOccuMulti.Rd
+++ b/man/unmarkedFrameOccuMulti.Rd
@@ -4,7 +4,8 @@
 
 \alias{unmarkedFrameOccuMulti}
 
-\usage{unmarkedFrameOccuMulti(y, siteCovs=NULL, obsCovs=NULL, mapInfo)}
+\usage{unmarkedFrameOccuMulti(y, siteCovs=NULL, obsCovs=NULL, 
+                              maxOrder, mapInfo)}
 
 \description{Organizes detection, non-detection data for multiple species along 
     with the covariates. This S4 class is required by the data argument 
@@ -20,6 +21,10 @@
     \item{obsCovs}{Either a named list of \code{\link{data.frame}}s of 
         covariates that vary within sites, or a \code{\link{data.frame}} with 
         RxJ rows in site-major order.}
+    \item{maxOrder}{Optional; specify maximum interaction order. Defaults to 
+        number of species (all possible interactions). Reducing this value may
+        speed up creation of unmarked frame if you aren't interested in 
+        higher-order interactions.}
     \item{mapInfo}{Currently ignored}
   
 }


### PR DESCRIPTION
Add maxOrder argument to unmarkedFrameOccuMulti, so you can create the frame in a reasonable amount of time if you have a large number of species. Fixes #136.