### PR TITLE
A few more tests for fixing predict

### DIFF
--- a/inst/unitTests/runit.occu.R
+++ b/inst/unitTests/runit.occu.R
@@ -206,3 +206,51 @@ test.occu.cloglog <- function() {
   #Check error if wrong link function
   checkException(occu(~ele+wind ~ele+forest, occ.frame, linkPsi="fake"))
 }
+
+test.occu.predict.complexFormulas <- function() {
+
+  y <- matrix(rep(0:1,10),5,2)
+  siteCovs <- data.frame(x = c(0,2,3,4,1))
+  obsCovs <- data.frame(o1 = 1:10, o2 = exp(-5:4)/10)
+  umf <- unmarkedFrameOccu(y = y, siteCovs = siteCovs, obsCovs = obsCovs)
+  fm <- occu(~ scale(o1) + o2 ~ x, data = umf)
+  
+  #Predict values should not depend on means/variance of newdata itself
+  nd1 <- obsCovs(umf[1:2,])
+  pr1 <- predict(fm, 'det', newdata=nd1)
+  nd2 <- obsCovs(umf[1:4,])
+  pr2 <- predict(fm, 'det', newdata=nd2)[1:4,]
+  
+  checkEqualsNumeric(pr1, pr2)
+
+  #Check factors
+  siteCovs$fac_cov <- factor(sample(c('a','b','c'), 5, replace=T),
+                             levels=c('b','a','c'))
+
+  umf <- unmarkedFrameOccu(y = y, siteCovs = siteCovs, obsCovs = obsCovs)
+  fm <- occu(~ o1 + o2 ~ fac_cov, data = umf)
+
+  pr3 <- predict(fm, 'state', newdata=data.frame(fac_cov=c('a','b')))
+  pr4 <- predict(fm, 'state', newdata=data.frame(fac_cov=c('b','a')))
+
+  checkEqualsNumeric(as.matrix(pr3),as.matrix(pr4[2:1,]))
+  checkException(predict(fm, 'state', newdata=data.frame(fac_cov=c('a','d'))))
+
+}
+
+## Add some checks here.
+test.occu.offest <- function() {
+
+  y <- matrix(rep(0:1,10),5,2)
+  siteCovs <- data.frame(x = c(0,2,3,4,1))
+  obsCovs <- data.frame(o1 = 1:10, o2 = exp(-5:4)/10)
+  umf <- unmarkedFrameOccu(y = y, siteCovs = siteCovs, obsCovs = obsCovs)
+  fm <- occu(~ o1 + o2 ~ offset(x), data = umf)
+  checkEqualsNumeric(coef(fm),
+                     structure(c(9.74361, 0.44327, -0.14683, 0.44085), .Names = c("psi(Int)", 
+"p(Int)", "p(o1)", "p(o2)")), tol = 1e-5)
+  fm <- occu(~ o1 + offset(o2) ~ offset(x), data = umf)
+  checkEqualsNumeric(coef(fm), structure(c(8.59459, 0.97574, -0.3096), .Names = c("psi(Int)", 
+"p(Int)", "p(o1)")), tol=1e-5)
+
+}


### PR DESCRIPTION
A couple simple tests to confirm the changes @aosmith16 to `predict` are working. I made the assumption that if `scale` in formulas works, then other functions should as well. If that's not necessarily true we may need more tests. I tested only `occu` since the other fitting functions used basically the exact same new code. And finally I added tests to `occuTTD`, which uses the `colext` `predict` method, just to make sure the pass-through trick I was using works with these changes. Along with the other 2 PRs I sent recently (#158, #159), I think we can safely close #29, #115, and #155 