### PR TITLE
Remove reshape2 dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,11 @@
 Package: unmarked
-Version: 0.13-1.9002
-Date: 2020-01-25
+Version: 0.13-1.9003
+Date: 2020-02-01
 Type: Package
 Title: Models for Data from Unmarked Animals
 Author: Ian Fiske, Richard Chandler, David Miller, Andy Royle, Marc Kery, Jeff Hostetler, Rebecca Hutchinson, Adam Smith, Ken Kellner 
 Maintainer: Andy Royle <aroyle@usgs.gov>
-Depends: R (>= 2.12.0), methods, lattice, parallel, Rcpp (>= 0.8.0), reshape2
+Depends: R (>= 2.12.0), methods, lattice, parallel, Rcpp (>= 0.8.0)
 Imports: graphics, stats, utils, plyr, raster, Matrix, MASS
 Description: Fits hierarchical models of animal abundance and occurrence to data collected using survey methods such as point counts, site occupancy sampling, distance sampling, removal sampling, and double observer sampling. Parameters governing the state and observation processes can be modeled as functions of covariates.
 License: GPL (>=3)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,11 +1,11 @@
 # Methods needed from other packages
 importFrom(stats, confint, fitted, coef, vcov, predict, update, profile,
-    simulate, residuals, logLik, as.formula, binomial, cov, dbinom,
+           simulate, residuals, logLik, as.formula, binomial, cov, dbinom,
            dmultinom, dnbinom, dnorm, dpois, formula,
            glm.fit, integrate, median, model.frame,
            model.matrix, model.offset, na.omit, optim, pchisq, plogis,
            pnorm, qchisq, qnorm, quantile, rbinom,
-           rmultinom, rnbinom, rpois, runif, sd, uniroot,
+           reshape, rmultinom, rnbinom, rpois, runif, sd, uniroot,
            update.formula)
 importFrom(graphics, plot, hist, abline)
 importFrom(utils, head, read.csv)
@@ -15,7 +15,7 @@ importFrom("raster","stack")
 importFrom("raster", "raster", "extent", "extent<-", "getValues") ## MM
 importFrom("MASS", "mvrnorm")
 
-import(lattice, methods, parallel, Rcpp, reshape2, Matrix)
+import(lattice, methods, parallel, Rcpp, Matrix)
 
 # Fitting functions
 export(occu, occuFP, occuRN, pcount, pcountOpen, multinomPois, distsamp,

--- a/R/getDesign.R
+++ b/R/getDesign.R
@@ -531,8 +531,11 @@ setMethod("getDesign", "unmarkedFrameOccuMulti",
                    x
           })
   ylong <- as.data.frame(do.call(rbind,ylong))
-  ylong <- melt(ylong,id.vars=c("site","species"),variable.name='sample')
-  ylong <- dcast(ylong, site + sample ~ species)
+  ylong <- reshape(ylong, idvar=c("site", "species"), varying=list(1:J),
+                   v.names="value", direction="long")
+  ylong <- reshape(ylong, idvar=c("site","time"), v.names="value",
+                    timevar="species", direction="wide")
+  ylong <- ylong[order(ylong$site, ylong$time), ]
 
   #Remove missing values
   if(na.rm){

--- a/R/unmarkedFrame.R
+++ b/R/unmarkedFrame.R
@@ -859,8 +859,9 @@ setMethod("plot", c(x="unmarkedFrame", y="missing"),
     y$site <- 1:M
     sites.per.panel <- M/panels
     y$group <- as.factor(round(seq(1,panels,length=M)))
-    y2 <- melt(y, #measure.vars = c("V1", "V2", "V3"),
-        id.vars=c("site","group"))
+    y2 <- reshape(y, idvar=c("site", "group"), varying=list(1:ncol(getY(x))),
+              v.names="value", direction="long")
+    y2$variable <- factor(paste("obs", y2$time))
     if(missing(colorkey))
         colorkey <- list(at=0:(ym+1), labels=list(labels=as.character(0:ym),
             at=(0:ym)+0.5))
@@ -881,8 +882,9 @@ setMethod("plot", c(x="unmarkedFrameOccuMulti", y="missing"),
     colnames(y) <- paste("obs",1:J)
     y$site <- rep(1:M,S)
     y$species <- as.factor(rep(names(x@ylist),each=M))
-    y2 <- melt(y, #measure.vars = c("V1", "V2", "V3"),
-        id.vars=c("site","species"))
+    y2 <- reshape(y, idvar=c("site", "species"), varying=list(1:obsNum(x)),
+              v.names="value", direction="long")
+    y2$variable <- factor(paste("obs", y2$time))
     if(missing(colorkey))
         colorkey <- list(at=0:(ym+1), labels=list(labels=as.character(0:ym),
             at=(0:ym)+0.5))


### PR DESCRIPTION
`reshape2` doesn't seem to be actively developed anymore, being superseded by `tidyr`. It isn't used much in `unmarked` and where it is used it can be replaced by `stats::reshape`, thus, this PR.

Based on the relevant tests, this change does not reintroduce the issues with factors and `formatLong` fixed in 79870d02. The covariate data frame is re-arranged via indexing rather than melting/casting so there aren't any changes in column classes.

This PR doesn't fix a specific bug and isn't strictly necessary at the moment, but I was looking into #65 and ended up writing it. So feel free not to merge. Either way I think we can close #65.