### PR TITLE
Make namespace more explicit, avoid unnecessarily package loads

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,8 +5,9 @@ Type: Package
 Title: Models for Data from Unmarked Animals
 Author: Ian Fiske, Richard Chandler, David Miller, Andy Royle, Marc Kery, Jeff Hostetler, Rebecca Hutchinson, Adam Smith, Ken Kellner 
 Maintainer: Andy Royle <aroyle@usgs.gov>
-Depends: R (>= 2.12.0), methods, lattice, parallel, Rcpp (>= 0.8.0)
-Imports: graphics, stats, utils, plyr, raster, Matrix, MASS
+Depends: R (>= 2.12.0), methods, lattice
+Imports: graphics, stats, utils, parallel, plyr, raster, Matrix, MASS,
+         Rcpp (>= 0.8.0)
 Description: Fits hierarchical models of animal abundance and occurrence to data collected using survey methods such as point counts, site occupancy sampling, distance sampling, removal sampling, and double observer sampling. Parameters governing the state and observation processes can be modeled as functions of covariates.
 License: GPL (>=3)
 LazyLoad: yes
@@ -24,3 +25,4 @@ URL: http://groups.google.com/group/unmarked,
      https://sites.google.com/site/unmarkedinfo/home,
      http://github.com/ianfiske/unmarked,
      http://github.com/rbchan/unmarked
+BugReports: https://github.com/rbchan/unmarked/issues

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -11,11 +11,14 @@ importFrom(graphics, plot, hist, abline)
 importFrom(utils, head, read.csv)
 importFrom(plyr, ldply, alply, ddply)
 importFrom(grDevices, devAskNewPage, dev.interactive)
-importFrom("raster","stack")
-importFrom("raster", "raster", "extent", "extent<-", "getValues") ## MM
-importFrom("MASS", "mvrnorm")
-
-import(lattice, methods, parallel, Rcpp, Matrix)
+importFrom(raster, raster, stack, extent, "extent<-", getValues)
+importFrom(MASS, mvrnorm)
+importFrom(parallel, detectCores, makeCluster, stopCluster, clusterExport,
+           clusterEvalQ, parLapply)
+importFrom(methods, is, as, new, show, slot, .hasSlot, callGeneric, 
+           callNextMethod)
+importFrom(lattice, xyplot, levelplot)
+import(Rcpp)
 
 # Fitting functions
 export(occu, occuFP, occuRN, pcount, pcountOpen, multinomPois, distsamp,

--- a/R/occuMulti.R
+++ b/R/occuMulti.R
@@ -32,7 +32,7 @@ occuMulti <- function(detformulas, stateformulas,  data, maxOrder, starts,
 
   dmF <- Matrix::Matrix(dmF, sparse=TRUE) # convert to sparse matrix
   #Only transpose once
-  t_dmF <- t(dmF)
+  t_dmF <- Matrix::t(dmF)
   #----------------------------------------------------------------------------
 
   #Likelihood function in R----------------------------------------------------


### PR DESCRIPTION
Moves `parallel` and `Rcpp` from depends to imports (so they no longer need to be explicitly loaded when `unmarked` is), and where possible `unmarked` now uses `importFrom` instead of `imports`. Ideally `lattice` would also be moved out of `depends` but doing so causes issues with some vignettes and examples that are expecting it to be loaded.

These changes make `unmarked` a bit more in line with my understanding of NAMESPACE best practices, but they are not crucial. There are no changes as far as I know to user-facing behavior.