### PR TITLE
Update package authors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,10 +1,23 @@
 Package: unmarked
-Version: 0.13-2.9003
-Date: 2020-03-27
+Version: 0.13-2.9004
+Date: 2020-03-30
 Type: Package
 Title: Models for Data from Unmarked Animals
-Author: Ian Fiske, Richard Chandler, David Miller, Andy Royle, Marc Kery, Jeff Hostetler, Rebecca Hutchinson, Adam Smith, Ken Kellner 
-Maintainer: Andy Royle <aroyle@usgs.gov>
+Authors@R: c(
+    person("Ian", "Fiske", role="aut"), 
+    person("Richard", "Chandler", role="aut"), 
+    person("David", "Miller", role="aut"),
+    person("Andy", "Royle", email="aroyle@usgs.gov", role=c("cre", "aut")),
+    person("Jeff", "Hostetler", role="aut"),
+    person("Rebecca", "Hutchinson", role="aut"),
+    person("Adam", "Smith", role="aut"),
+    person("Ken", "Kellner", role="aut"),
+    person("Marc", "Kery", role="ctb"),
+    person("Mike", "Meredith", role="ctb"),
+    person("Auriel", "Fournier", role="ctb"),
+    person("Ariel", "Muldoon", role="ctb"),
+    person("Chris", "Baker", role="ctb")
+    )
 Depends: R (>= 2.12.0), methods, lattice, parallel, Rcpp (>= 0.8.0)
 Imports: graphics, stats, utils, plyr, raster, Matrix, MASS
 Description: Fits hierarchical models of animal abundance and occurrence to data collected using survey methods such as point counts, site occupancy sampling, distance sampling, removal sampling, and double observer sampling. Parameters governing the state and observation processes can be modeled as functions of covariates.


### PR DESCRIPTION
As discussed. Apparently for R 'creator' and 'maintainer' are equivalent so Andy is assigned as `'cre'`. I left out one author (Stefan Theussl) because they were the author of the very first commit (which didn't make sense - maybe Ian copied an existing repository when he started and built off that?). Fixes #173.