### PR TITLE
Convert characters to factors with warning when building umf

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: unmarked
-Version: 1.0.0.9002
-Date: 2020-05-27
+Version: 1.0.0.9003
+Date: 2020-06-02
 Type: Package
 Title: Models for Data from Unmarked Animals
 Authors@R: c(

--- a/R/unmarkedFrame.R
+++ b/R/unmarkedFrame.R
@@ -190,6 +190,7 @@ unmarkedFrame <- function(y, siteCovs = NULL, obsCovs = NULL, mapInfo,
 
     umf <- new("unmarkedFrame", y = y, obsCovs = obsCovs, siteCovs = siteCovs,
         mapInfo = mapInfo, obsToY = obsToY)
+    umf <- umf_to_factor(umf)
     return(umf)
 }
 
@@ -207,6 +208,7 @@ unmarkedFrameDS <- function(y, siteCovs = NULL, dist.breaks, tlength,
                  siteCovs = siteCovs, dist.breaks = dist.breaks,
                  tlength = tlength, survey = survey, unitsIn = unitsIn,
                  obsToY = matrix(1, 1, ncol(y)))
+    umfds <- umf_to_factor(umfds)
     return(umfds)
 }
 
@@ -262,6 +264,7 @@ unmarkedFrameOccuMulti <- function(y, siteCovs = NULL, obsCovs = NULL,
   
   umfmo <- new("unmarkedFrameOccuMulti", y=y, ylist = ylist, fDesign=fDesign,
                obsCovs = obsCovs, siteCovs = siteCovs, obsToY = diag(J))
+  umfmo <- umf_to_factor(umfmo)
   return(umfmo)
 }
 
@@ -323,6 +326,7 @@ unmarkedMultFrame <- function(y, siteCovs = NULL, obsCovs = NULL,
     umf@numPrimary <- numPrimary
     umf@yearlySiteCovs <- covsToDF(yearlySiteCovs, "yearlySiteCovs", 
                                    numPrimary, nrow(y))
+    umf <- umf_to_factor(umf)
     umf
 }
 
@@ -442,6 +446,7 @@ unmarkedFrameGMM <- function(y, siteCovs = NULL, obsCovs = NULL, numPrimary,
     umf <- as(umf, "unmarkedFrameGMM")
     umf@piFun <- piFun
     umf@samplingMethod <- type
+    umf <- umf_to_factor(umf)
     umf
 }
 
@@ -511,6 +516,7 @@ unmarkedFrameDSO <- function(y, siteCovs=NULL, yearlySiteCovs=NULL, numPrimary,
     umf@unitsIn <- unitsIn
     umf@tlength <- tlength
     umf@primaryPeriod <- primaryPeriod
+    umf <- umf_to_factor(umf)
     umf
 }
 
@@ -557,6 +563,7 @@ unmarkedFrameGDS<- function(y, siteCovs, numPrimary,
     umf@survey <- survey
     umf@unitsIn <- unitsIn
     umf@tlength <- tlength
+    umf <- umf_to_factor(umf)
     umf
 }
 
@@ -615,6 +622,7 @@ unmarkedFrameGPC <- function(y, siteCovs=NULL, obsCovs=NULL, numPrimary,
     umf@yearlySiteCovs <- covsToDF(yearlySiteCovs, "yearlySiteCovs", 
                                    numPrimary, nrow(y))
     umf <- as(umf, "unmarkedFrameGPC")
+    umf <- umf_to_factor(umf)
     umf
 }
 
@@ -662,6 +670,7 @@ unmarkedFramePCO <- function(y, siteCovs = NULL, obsCovs = NULL,
     umf <- as(umf, "unmarkedFramePCO")
     umf@primaryPeriod <- primaryPeriod
     # There is no obsToY function
+    umf <- umf_to_factor(umf)
     return(umf)
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -127,7 +127,7 @@ parmNames <- function(list.df) {
 csvToUMF <-
 function(filename, long=FALSE, type, species = NULL, ...)
 {
-  dfin <- read.csv(filename)
+  dfin <- read.csv(filename, stringsAsFactors=TRUE)
 
   if(long == TRUE) return(formatLong(dfin, species, type = type, ...))
   else return(formatWide(dfin, type = type, ...))
@@ -849,3 +849,25 @@ rmultinom2 <- function(n, size, prob){
 
 }
 
+#Functions to convert character columns to factors
+df_to_factor <- function(df, name="Input"){
+  if(is.null(df)) return(NULL)
+  stopifnot(inherits(df, "data.frame"))
+  char_cols <- sapply(df, is.character)
+  if(any(char_cols)){
+    warning(paste(name, "contains characters. Converting them to factors."), call.=FALSE)
+  }
+  to_change <- df[,char_cols, drop=FALSE]
+  df[,char_cols] <- lapply(to_change, as.factor)
+  df
+}
+
+umf_to_factor <- function(umf){
+  stopifnot(inherits(umf, "unmarkedFrame"))
+  umf@siteCovs <- df_to_factor(siteCovs(umf), "siteCovs")
+  umf@obsCovs <- df_to_factor(obsCovs(umf), "obsCovs")
+  if(methods::.hasSlot(umf, "yearlySiteCovs")){
+    umf@yearlySiteCovs <- df_to_factor(yearlySiteCovs(umf), "yearlySiteCovs") 
+  }
+  umf 
+}

--- a/inst/unitTests/runit.unmarkedFrame.R
+++ b/inst/unitTests/runit.unmarkedFrame.R
@@ -102,3 +102,75 @@ test.umf.yearlySiteCovs <- function() {
   checkEqualsNumeric(dim(as_df2),c(50,25))
 
 }
+
+test.umf.char.to.factor <- function(){
+
+  n <- 50   # number of sites
+  T <- 4    # number of primary periods
+  J <- 3    # number of secondary periods
+
+  y <- matrix(0:1, n, J*T)
+
+  #Site covs
+  sc <- data.frame(x=rnorm(n), y=sample(letters, 50, replace=TRUE))
+  checkEquals(sapply(sc, class), c(x="numeric", y="character"))
+  
+  options(warn=2)
+  checkException(umf <- unmarkedFrame(y, siteCovs=sc))
+  options(warn=0)
+  umf <- unmarkedFrame(y, siteCovs=sc)
+  checkEquals(sapply(siteCovs(umf), class), c(x="numeric", y="factor"))
+
+  #Already factor
+  sc2 <- data.frame(x=rnorm(n), y=factor(sample(letters, 50, replace=TRUE)))
+  umf <- unmarkedFrame(y, siteCovs=sc2)
+  checkEquals(sapply(siteCovs(umf), class), c(x="numeric", y="factor"))
+
+  #Obs covs
+  oc <- data.frame(x=rnorm(n*J*T), y=sample(letters, n*J*T, replace=TRUE))
+  checkEquals(sapply(oc, class), c(x="numeric", y="character"))
+  
+  options(warn=2)
+  checkException(umf <- unmarkedFrame(y, obsCovs=oc))
+  options(warn=0)
+  umf <- unmarkedFrame(y, obsCovs=oc)
+  checkEquals(sapply(obsCovs(umf), class), c(x="numeric", y="factor"))
+  checkTrue(is.null(siteCovs(umf)))
+
+  #as list
+  oc <- list(x=matrix(oc$x, nrow=n), y=matrix(oc$y, nrow=n))
+  options(warn=2)
+  checkException(umf <- unmarkedFrameOccu(y, obsCovs=oc))
+  options(warn=0)
+  umf <- unmarkedFrameOccu(y, obsCovs=oc)
+  checkEquals(sapply(obsCovs(umf), class), c(x="numeric", y="factor"))
+  checkTrue(is.null(siteCovs(umf)))
+  
+  #Check conversion
+  df <- as(umf, "data.frame")
+  checkEqualsNumeric(dim(df), c(50,36))
+
+  #Yearly site covs
+  ysc <- list(x=matrix(rnorm(n*T), nrow=n), 
+             y=matrix(sample(letters, n*T, replace=TRUE), nrow=n))
+  options(warn=2)
+  checkException(umf <- unmarkedMultFrame(y, yearlySiteCovs=ysc, numPrimary=T))
+  options(warn=0)
+  umf <- unmarkedMultFrame(y, yearlySiteCovs=ysc, numPrimary=T)
+  checkEquals(sapply(yearlySiteCovs(umf), class), c(x="numeric", y="factor"))
+  checkTrue(is.null(siteCovs(umf)))
+
+  #All
+  options(warn=2)
+  checkException(umf <- unmarkedMultFrame(y, yearlySiteCovs=ysc, obsCovs=oc, 
+                                          siteCovs=sc, numPrimary=T))
+  options(warn=0)
+  umf <- unmarkedMultFrame(y, yearlySiteCovs=ysc, obsCovs=oc, 
+                          siteCovs=sc, numPrimary=T)
+  checkEquals(sapply(yearlySiteCovs(umf), class), c(x="numeric", y="factor"))
+  checkEquals(sapply(obsCovs(umf), class), c(x="numeric", y="factor"))
+  checkEquals(sapply(obsCovs(umf), class), c(x="numeric", y="factor"))
+  
+  df <- as(umf, "data.frame")
+  checkEqualsNumeric(dim(df), c(50,46)) 
+}

--- a/inst/unitTests/runit.utils.R
+++ b/inst/unitTests/runit.utils.R
@@ -233,3 +233,20 @@ test.invertHessian <- function(){
   checkEqualsNumeric(unmarked:::invertHessian(bad_opt, nrow(bad_opt$hessian), FALSE),
                      matrix(rep(NA,4), nrow=2))
 }
+
+test.csvToUMF <- function(){
+  
+  options(warn=2)
+  checkException(umf <- csvToUMF(system.file("csv","csv_factor_test.csv", 
+                                  package = "unmarked"), type="unmarkedFrameOccu"))
+  options(warn=0)
+
+  umf <- csvToUMF(system.file("csv","csv_factor_test.csv", 
+                  package = "unmarked"), type="unmarkedFrameOccu")
+
+  checkEquals(sapply(siteCovs(umf), class), c(elev="numeric", forest="factor"))
+  checkEquals(sapply(obsCovs(umf), class), c(wind="numeric", rain="factor"))
+  
+  df <- as(umf, "data.frame")
+  checkEqualsNumeric(dim(df), c(20,11)) 
+}


### PR DESCRIPTION
This should cover all the `unmarkedFrame` functions and also `csvToUMF`. The new tests cover the basic frame types, but I didn't write separate tests for every individual UMF class. Should fix #179.