### PR TITLE
Define STRICT_R_HEADERS and fix resulting problems

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: unmarked
-Version: 1.0.1.9014
-Date: 2021-04-09
+Version: 1.0.1.9015
+Date: 2021-04-27
 Type: Package
 Title: Models for Data from Unmarked Animals
 Authors@R: c(

--- a/src/Makevars
+++ b/src/Makevars
@@ -28,4 +28,4 @@ clean:
 ## Use the R_HOME indirection to support installations of multiple R version
 PKG_LIBS = $(shell $(R_HOME)/bin/Rscript -e "Rcpp:::LdFlags()" ) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) $(SHLIB_OPENMP_CXXFLAGS)
 PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS)
-
+PKG_CPPFLAGS=-DSTRICT_R_HEADERS

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -31,3 +31,4 @@ PKG_LIBS = $(shell "$(R_HOME)/bin${R_ARCH_BIN}/Rscript.exe" -e "Rcpp:::LdFlags()
 ##PKG_LIBS+= -lRcpp
 ##PKG_LIBS+= -LC:/PROGRA~1/R/R-3.0.0/library/Rcpp/libs${R_ARCH_BIN}
 PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS)
+PKG_CPPFLAGS=-DSTRICT_R_HEADERS

--- a/src/nll_distsamp.cpp
+++ b/src/nll_distsamp.cpp
@@ -19,7 +19,7 @@ SEXP nll_distsamp( SEXP y_, SEXP lam_, SEXP sig_, SEXP scale_, SEXP a_, SEXP u_,
 
   //  double mu = 0.0;
   double ll = 0.0;
-  double lnmin = log(DOUBLE_XMIN);
+  double lnmin = log(DBL_MIN);
 
   double f0 = 0.0;
 

--- a/src/nll_distsamp.h
+++ b/src/nll_distsamp.h
@@ -2,6 +2,7 @@
 #define _UNMARKED_NLL_DISTSAMP_H
 
 #include <Rcpp.h>
+#include <float.h>
 #include "detfuns.h"
 
 RcppExport SEXP nll_distsamp( SEXP y_, SEXP lam_, SEXP sig_, SEXP scale_, SEXP a_, SEXP u_, SEXP w_, SEXP db_, SEXP keyfun_, SEXP survey_, SEXP reltol_ ) ;

--- a/src/nll_distsampOpen.cpp
+++ b/src/nll_distsampOpen.cpp
@@ -324,7 +324,7 @@ SEXP nll_distsampOpen( SEXP y_, SEXP yt_, SEXP Xlam_, SEXP Xgam_, SEXP Xom_,
       ll_i += sum(g2star);
     }
 
-    ll += log(ll_i + DOUBLE_XMIN);
+    ll += log(ll_i + DBL_MIN);
 
   }
 

--- a/src/nll_distsampOpen.h
+++ b/src/nll_distsampOpen.h
@@ -2,6 +2,7 @@
 #define _unmarked_NLL_DISTSAMPOPEN_H
 
 #include <RcppArmadillo.h>
+#include <float.h>
 #include "tranprobs.h"
 #include "distprob.h"
 #include "distr.h"

--- a/src/nll_gdistsamp.cpp
+++ b/src/nll_gdistsamp.cpp
@@ -1,4 +1,5 @@
 #include <RcppArmadillo.h>
+#include <float.h>
 #include "distprob.h"
 #include "distr.h"
 #include "utils.h"
@@ -86,7 +87,7 @@ double nll_gdistsamp(arma::vec beta, arma::uvec n_param, arma::vec y,
         exp(sum(mn.row(j)));
     }
 
-    loglik += log(site_lp + DOUBLE_XMIN);
+    loglik += log(site_lp + DBL_MIN);
 
   }
 

--- a/src/nll_multmixOpen.cpp
+++ b/src/nll_multmixOpen.cpp
@@ -313,7 +313,7 @@ SEXP nll_multmixOpen( SEXP y_, SEXP yt_, SEXP Xlam_, SEXP Xgam_, SEXP Xom_,
       ll_i += sum(g2star);
     }
 
-    ll += log(ll_i + DOUBLE_XMIN);
+    ll += log(ll_i + DBL_MIN);
 
   }
 

--- a/src/nll_multmixOpen.h
+++ b/src/nll_multmixOpen.h
@@ -2,6 +2,7 @@
 #define _unmarked_NLL_MULTMIXOPEN_H
 
 #include <RcppArmadillo.h>
+#include <float.h>
 #include "tranprobs.h"
 #include "distr.h"
 #include "pifun.h"

--- a/src/nll_occu.cpp
+++ b/src/nll_occu.cpp
@@ -14,23 +14,23 @@ SEXP nll_occu( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_psiR, SEXP beta_pR, SEXP ndR
   arma::colvec X_offset = as<arma::colvec>(X_offsetR);
   arma::colvec V_offset = as<arma::colvec>(V_offsetR);
   std::string link_psi = as<std::string>(link_psiR);
-  
+
   int R = X.n_rows;
   int J = y.n_elem / R;
-  
+
   //Calculate psi
   arma::colvec psi_lp = X*beta_psi + X_offset;
   arma::colvec psi(R);
   if(link_psi == "cloglog"){
     psi = 1 - exp(-exp(psi_lp));
-  } else { 
+  } else {
     psi = 1.0/(1.0+exp(-psi_lp));
   }
-  
+
   //Calculate p
   arma::colvec logit_p = V*beta_p + V_offset;
   arma::colvec p = 1.0/(1.0+exp(-logit_p));
-  
+
   double ll=0.0;
   int k=0; // counter
   for(int i=0; i<R; i++) {
@@ -43,9 +43,9 @@ SEXP nll_occu( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_psiR, SEXP beta_pR, SEXP ndR
     if(knownOcc(i))
       psi(i) = 1.0;
     if(nd(i)==0)
-      ll += log(cp * psi(i) + DOUBLE_XMIN);
+      ll += log(cp * psi(i) + DBL_MIN);
     else if(nd(i)==1)
-      ll += log(cp * psi(i) + (1-psi(i)) + DOUBLE_XMIN);
+      ll += log(cp * psi(i) + (1-psi(i)) + DBL_MIN);
   }
   return wrap(-ll);
 }

--- a/src/nll_occu.h
+++ b/src/nll_occu.h
@@ -2,6 +2,7 @@
 #define _unmarked_NLL_OCCU_H
 
 #include <RcppArmadillo.h>
+#include <float.h>
 
 RcppExport SEXP nll_occu( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_psiR, SEXP beta_pR, SEXP ndR, SEXP knownOccR, SEXP navecR, SEXP X_offsetR, SEXP V_offsetR, SEXP link_psiR ) ;
 

--- a/src/nll_occuPEN.cpp
+++ b/src/nll_occuPEN.cpp
@@ -33,9 +33,9 @@ SEXP nll_occuPEN( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_psiR, SEXP beta_pR, SEXP 
     if(knownOcc(i))
       psi(i) = 1.0;
     if(nd(i)==0)
-      ll += log(cp * psi(i) + DOUBLE_XMIN);
+      ll += log(cp * psi(i) + DBL_MIN);
     else if(nd(i)==1)
-      ll += log(cp * psi(i) + (1-psi(i)) + DOUBLE_XMIN);
+      ll += log(cp * psi(i) + (1-psi(i)) + DBL_MIN);
   }
   ll = ll - penalty;
   return wrap(-ll);

--- a/src/nll_occuPEN.h
+++ b/src/nll_occuPEN.h
@@ -2,6 +2,7 @@
 #define _unmarked_NLL_OCCUPEN_H
 
 #include <RcppArmadillo.h>
+#include <float.h>
 
 RcppExport SEXP nll_occuPEN( SEXP yR, SEXP Xr, SEXP Vr, SEXP beta_psiR, SEXP beta_pR, SEXP ndR, SEXP knownOccR, SEXP navecR, SEXP X_offsetR, SEXP V_offsetR, SEXP penaltyR ) ;
 

--- a/src/nll_occuRN.cpp
+++ b/src/nll_occuRN.cpp
@@ -1,4 +1,5 @@
 #include <RcppArmadillo.h>
+#include <float.h>
 #include "utils.h"
 
 #ifdef _OPENMP
@@ -25,7 +26,7 @@ double lp_site_occuRN(const rowvec y, double lam, const vec q, int K, int Kmin){
     }
     out += f * exp(g);
   }
-  return log(out + DOUBLE_XMIN);
+  return log(out + DBL_MIN);
 }
 
 // [[Rcpp::export]]

--- a/src/nll_pcount.cpp
+++ b/src/nll_pcount.cpp
@@ -1,4 +1,5 @@
 #include <RcppArmadillo.h>
+#include <float.h>
 #include "distr.h"
 #include "utils.h"
 
@@ -25,7 +26,7 @@ double lp_site_pcount(const rowvec y, int mixture, double lam, double log_alpha,
     }
     out += f * exp(g);
   }
-  return log(out + DOUBLE_XMIN);
+  return log(out + DBL_MIN);
 }
 
 

--- a/src/nll_pcountOpen.cpp
+++ b/src/nll_pcountOpen.cpp
@@ -230,7 +230,7 @@ SEXP nll_pcountOpen( SEXP y_, SEXP Xlam_, SEXP Xgam_, SEXP Xom_, SEXP Xp_, SEXP 
       g_star = g3_d * g1_star;
       ll_i = arma::dot(g2, g_star);
     }
-    ll += log(ll_i + DOUBLE_XMIN);
+    ll += log(ll_i + DBL_MIN);
   }
   return wrap(-ll);
 }

--- a/src/nll_pcountOpen.h
+++ b/src/nll_pcountOpen.h
@@ -2,6 +2,7 @@
 #define _unmarked_NLL_PCOUNTOPEN_H
 
 #include "tranprobs.h"
+#include <float.h>
 
 RcppExport SEXP nll_pcountOpen( SEXP y_, SEXP Xlam_, SEXP Xgam_, SEXP Xom_, SEXP Xp_, SEXP Ximm_, SEXP beta_lam_, SEXP beta_gam_, SEXP beta_om_, SEXP beta_p_, SEXP beta_imm_, SEXP log_alpha_, SEXP Xlam_offset_, SEXP Xgam_offset_, SEXP Xom_offset_, SEXP Xp_offset_, SEXP Ximm_offset_, SEXP ytna_, SEXP yna_, SEXP lk_, SEXP mixture_, SEXP first_, SEXP last_, SEXP M_, SEXP J_, SEXP T_, SEXP delta_, SEXP dynamics_, SEXP fix_, SEXP go_dims_, SEXP immigration_, SEXP I_, SEXP I1_, SEXP Ib_, SEXP Ip_) ;
 


### PR DESCRIPTION
This PR addresses the issues raised in https://github.com/RcppCore/Rcpp/issues/1158. Rather than define `STRICT_R_HEADERS` in many files I instead added `PKG_CPPFLAGS=-DSTRICT_R_HEADERS` to the `Makevars`. As expected this resulted in immediate failure to compile.

All that was required was to include `float.h` and change instances of `DOUBLE_XMIN` to `DBL_MIN` in a few files. The package checks clean for me now and the tests pass.

Fixes #201