### PR TITLE
Add progress bar to parametric bootstraps and cross-validations

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,7 @@ Imports:
     MASS,
     Matrix,
     parallel,
+    pbapply,
     plyr,
     raster,
     Rcpp (>= 0.8.0),

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -14,7 +14,7 @@ importFrom(grDevices, devAskNewPage, dev.interactive)
 importFrom(raster, raster, stack, extent, "extent<-", getValues)
 importFrom(MASS, mvrnorm)
 importFrom(parallel, detectCores, makeCluster, stopCluster, clusterExport,
-           clusterEvalQ, parLapply)
+           clusterEvalQ)
 importFrom(methods, is, as, new, show, slot, .hasSlot, callGeneric, 
            callNextMethod)
 importFrom(lattice, xyplot, levelplot)

--- a/R/boot.R
+++ b/R/boot.R
@@ -45,9 +45,6 @@ setMethod("parboot", "unmarkedFit",
     t0 <- statistic(object, ...)
     lt0 <- length(t0)
     t.star <- matrix(NA, nsim, lt0)
-    if(!is.null(names(t0)))
-        colnames(t.star) <- names(t0)
-    else colnames(t.star) <- paste("t*", 1:lt0, sep="")
     if(!missing(report))
         cat("t0 =", t0, "\n")
     simdata <- umf
@@ -60,21 +57,34 @@ setMethod("parboot", "unmarkedFit",
     no_par <- ncores < 2 || nsim < 100 || !parallel
 
     if (no_par) {
-      for(i in 1:nsim) {
-        simdata <- replaceY(simdata, simList[[i]])
-        fit <- update(object, data=simdata, starts=starts, se=FALSE)
-        t.star[i,] <- statistic(fit, ...)
-        if(!missing(report)) {
-          if (nsim > report && i %in% seq(report, nsim, by=report))
-            cat(paste(round(t.star[(i-(report-1)):i,], 1), collapse=","), fill=TRUE)
+      if (!missing(report)) {
+        for(i in 1:nsim) {
+          simdata <- replaceY(simdata, simList[[i]])
+          fit <- update(object, data=simdata, starts=starts, se=FALSE)
+          t.star[i,] <- statistic(fit, ...)
+          if(!missing(report)) {
+            if (nsim > report && i %in% seq(report, nsim, by=report))
+              cat("iter", i, ": ", t.star[i, ], "\n")
+          }
         }
-        out <- new("parboot", call=call, t0 = t0, t.star = t.star)
+      } else {
+        t.star <- pbapply::pbsapply(1:nsim, function(i) {
+          simdata <- replaceY(simdata, simList[[i]])
+          fit <- update(object, data=simdata, starts=starts, se=FALSE)
+          t.star.tmp <- statistic(fit, ...)
+        })
+        if (lt0 > 1) 
+          t.star <- t(t.star)
+        else 
+          t.star <- matrix(t.star, ncol = lt0)
       }
     } else {
-      if (!missing(report)) message("Running in parallel on ", ncores, " cores. Bootstrapped statistics not reported.")
+      message("Running parametric bootstrap in parallel on ", ncores, " cores.")
+      if (!missing(report)) message("Bootstrapped statistics not reported during parallel processing.")
       cl <- makeCluster(ncores)
+      if (!is.null(seed)) parallel::clusterSetRNGStream(cl, iseed = seed)
       on.exit(stopCluster(cl))
-      varList <- c("simList", "y", "object", "simdata", "ests", "statistic", "dots")
+      varList <- c("simList", "y", "object", "simdata", "starts", "statistic", "dots")
       # If call formula is an object, include it too
       fm.nms <- all.names(object@call)
       if (!any(grepl("~", fm.nms))) varList <- c(varList, fm.nms[2])
@@ -83,16 +93,17 @@ setMethod("parboot", "unmarkedFit",
       clusterExport(cl, varList, envir = environment())
       clusterEvalQ(cl, library(unmarked))
       clusterEvalQ(cl, list2env(dots))
-      t.star.parallel <- parLapply(cl, 1:nsim, function(i) {
+      t.star.parallel <- pbapply::pblapply(1:nsim, function(i) {
         simdata <- replaceY(simdata, simList[[i]])
         fit <- update(object, data = simdata, starts = starts, se = FALSE)
         t.star <- statistic(fit, ...)
-      })
+      }, cl = cl)
       t.star <- matrix(unlist(t.star.parallel), nrow = length(t.star.parallel), byrow = TRUE)
-      colnames(t.star) <- names(t.star.parallel[[1]])
-      out <- new("parboot", call = call, t0 = t0, t.star = t.star)
     }
-
+    if (!is.null(names(t0)))
+      colnames(t.star) <- names(t0)
+    else colnames(t.star) <- paste("t*", 1:lt0, sep="")
+    out <- new("parboot", call = call, t0 = t0, t.star = t.star)
     return(out)
 })
 

--- a/R/unmarkedCrossVal.R
+++ b/R/unmarkedCrossVal.R
@@ -59,10 +59,10 @@ setMethod("crossVal", "unmarkedFit",
   if(parallel){
     cl <- parallel::makeCluster(detectCores()-1)
     on.exit(parallel::stopCluster(cl))
-    stat_raw <- parallel::parLapply(cl, 1:n_reps, do_crossval, object, 
-                                     partitions, statistic, ...)
+    stat_raw <- pbapply::pblapply(1:n_reps, do_crossval, object, 
+                                     partitions, statistic, ..., cl = cl)
   } else {
-    stat_raw <- lapply(1:n_reps, do_crossval, object, 
+    stat_raw <- pbapply::pblapply(1:n_reps, do_crossval, object, 
                        partitions, statistic, ...)
   }
   

--- a/inst/unitTests/runit.parboot.R
+++ b/inst/unitTests/runit.parboot.R
@@ -31,7 +31,8 @@ test.parboot.occu <- function() {
 ##    frm.obj <- as.formula(paste("~", x.2, "~", x.1))
     fm1 <- occu(~x2 ~x1, umf)
 ##    fm2 <- occu(frm.obj, umf)
-    gof <- parboot(fm1, fitstats, nsim = 100, seed = 6546)
+    gof0 <- parboot(fm1, fitstats, nsim = 100, seed = 6546, parallel = FALSE)
+    gof1 <- parboot(fm1, fitstats, nsim = 100, seed = 6546, report = 100, parallel = FALSE)
 ##    gof2 <- parboot(fm2, fitstats, nsim = 100, seed = 6546)
 
 ##    checkEquals(gof@t.star, gof2@t.star)
@@ -195,7 +196,8 @@ test.parboot.occu <- function() {
 
   #Check parallel
   gof2 <- parboot(fm1, fitstats, nsim = 100, seed = 6546, parallel=TRUE)
-  checkTrue(all(gof@t.star==gof2@t.star))
+  checkIdentical(gof0@t.star, gof1@t.star)
+  checkIdentical(gof0@t.star, gof2@t.star)
 
 }
 

--- a/man/parboot.Rd
+++ b/man/parboot.Rd
@@ -15,7 +15,9 @@
   \item{seed}{set seed for reproducible bootstrap}
   \item{parallel}{logical (default = \code{TRUE}) indicating whether to compute 
     bootstrap on multiple cores, if present.  If \code{TRUE}, suppresses reporting
-    of bootstrapped statistics.  Defaults to serial calculation when \code{nsim} < 100.}
+    of bootstrapped statistics.  Defaults to serial calculation when \code{nsim} < 100.
+    Parallel computation is likely to be slower for simple models when \code{nsim} < ~500,
+    but should speed up the bootstrap of more complicated models.}
   \item{ncores}{integer (default = one less than number of available cores) number of cores to
     use when bootstrapping in parallel.} 
   \item{...}{Additional arguments to be passed to statistic}}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -2,9 +2,15 @@
 // Generator token: 10BE3573-1514-4C36-9D1C-5A225CD40393
 
 #include <RcppArmadillo.h>
+#include <RcppEigen.h>
 #include <Rcpp.h>
 
 using namespace Rcpp;
+
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
 
 // nll_gdistremoval
 double nll_gdistremoval(arma::vec beta, arma::uvec n_param, arma::vec yDistance, arma::vec yRemoval, arma::mat ysum, int mixture, std::string keyfun, arma::mat Xlam, arma::vec A, arma::mat Xphi, arma::mat Xrem, arma::mat Xdist, arma::vec db, arma::mat a, arma::mat u, arma::vec w, arma::uvec pl, int K, arma::uvec Kmin, int threads);


### PR DESCRIPTION
Use {pbapply} to provide bootstrap and cross-validation progress feedback to user. Ignored if reporting is requested on non-parallel bootstraps. `parboot` units tests modified as necessary and passed. No changes needed for `crossVal` unit tests, but tests passed.