### PR TITLE
Remove plyr as dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,6 @@ Imports:
     Matrix,
     parallel,
     pbapply,
-    plyr,
     Rcpp (>= 0.8.0),
     stats,
     TMB (>= 1.7.18),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: unmarked
-Version: 1.2.5
-Date: 2022-05-10
+Version: 1.2.5.9001
+Date: 2022-06-15
 Type: Package
 Title: Models for Data from Unmarked Animals
 Authors@R: c(

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -9,7 +9,6 @@ importFrom(stats, confint, fitted, coef, vcov, predict, update, profile,
            update.formula, sigma)
 importFrom(graphics, plot, hist, abline)
 importFrom(utils, head, read.csv)
-importFrom(plyr, ddply)
 importFrom(grDevices, devAskNewPage, dev.interactive, palette.colors)
 importFrom(MASS, mvrnorm)
 importFrom(parallel, detectCores, makeCluster, stopCluster, clusterExport,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -9,7 +9,7 @@ importFrom(stats, confint, fitted, coef, vcov, predict, update, profile,
            update.formula, sigma)
 importFrom(graphics, plot, hist, abline)
 importFrom(utils, head, read.csv)
-importFrom(plyr, ldply, alply, ddply)
+importFrom(plyr, ddply)
 importFrom(grDevices, devAskNewPage, dev.interactive, palette.colors)
 importFrom(MASS, mvrnorm)
 importFrom(parallel, detectCores, makeCluster, stopCluster, clusterExport,

--- a/R/boot.R
+++ b/R/boot.R
@@ -194,9 +194,7 @@ setMethod("nonparboot", "unmarkedFit",
         data.b <- data[sites,]
         y <- getY(data.b)
         if (bsType == "both") {
-            obs.per.site <- alply(y, 1, function(row) {
-                which(!is.na(row))
-            })
+            obs.per.site <- lapply(1:nrow(y), function(i) which(!is.na(y[i,])))
             obs <- lapply(obs.per.site,
                           function(obs) sample(obs, replace = TRUE))
             data.b <- data.b[obs]
@@ -382,9 +380,7 @@ setMethod("nonparboot", "unmarkedFitOccuPEN",
         data.b <- data[sites,]
         y <- getY(data.b)
         if (bsType == "both") {
-            obs.per.site <- alply(y, 1, function(row) {
-                which(!is.na(row))
-            })
+            obs.per.site <- lapply(1:nrow(y), function(i) which(!is.na(y[i,])))
             obs <- lapply(obs.per.site,
                           function(obs) sample(obs, replace = TRUE))
             data.b <- data.b[obs]
@@ -440,9 +436,7 @@ setMethod("nonparboot", "unmarkedFitOccuPEN_CV",
         data.b <- data[sites,]
         y <- getY(data.b)
         if (bsType == "both") {
-            obs.per.site <- alply(y, 1, function(row) {
-                which(!is.na(row))
-            })
+            obs.per.site <- lapply(1:nrow(y), function(i) which(!is.na(y[i,])))
             obs <- lapply(obs.per.site,
                           function(obs) sample(obs, replace = TRUE))
             data.b <- data.b[obs]

--- a/R/unmarkedFrame.R
+++ b/R/unmarkedFrame.R
@@ -1133,9 +1133,7 @@ setMethod("[", c("unmarkedFrame", "numeric", "missing", "missing"),
     if (!is.null(obsCovs)) {
         R <- obsNum(x)
         .site <- rep(1:M, each = R)
-        obsCovs <- ldply(i, function(site) {
-            subset(obsCovs, .site == site)
-            })
+        obsCovs <- obsCovs[.site%in%i,,drop=FALSE]
         }
     umf <- x
     umf@y <- y
@@ -1235,9 +1233,7 @@ setMethod("[", c("unmarkedFrameOccuMulti", "numeric", "missing", "missing"),
     if (!is.null(obsCovs)) {
         R <- obsNum(x)
         .site <- rep(1:M, each = R)
-        obsCovs <- ldply(i, function(site) {
-            subset(obsCovs, .site == site)
-            })
+        obsCovs <- obsCovs[.site%in%i,,drop=FALSE]
         }
     umf <- x
     umf@y <- ylist[[1]]
@@ -1310,9 +1306,7 @@ setMethod("[", c("unmarkedMultFrame", "numeric", "missing", "missing"),
     if (!is.null(obsCovs)) {
         R <- obsNum(x)
         .site <- rep(1:M, each = obsNum(x)) #NULL     ## testing
-        obsCovs <- ldply(i, function(site) {
-            subset(obsCovs, .site == site)
-            })
+        obsCovs <- obsCovs[.site%in%i,,drop=FALSE]
         }
     u <- unmarkedMultFrame(y=matrix(y, ncol=ncol(oldy)),
                            siteCovs=siteCovs,

--- a/R/unmarkedFrame.R
+++ b/R/unmarkedFrame.R
@@ -1192,17 +1192,20 @@ setMethod("[", c("unmarkedFrame","list", "missing", "missing"),
     if (m != length(i)) stop("list length must be same as number of sites.")
     siteCovs <- siteCovs(x)
     y <- cbind(.site=1:m, getY(x))
-    obsCovs <- as.data.frame(cbind(.site=rep(1:m, each=R), obsCovs(x)))
+    obsCovs <- obsCovs(x)
+    site_idx <- rep(1:m, each=R)
+    stopifnot(length(site_idx) == nrow(obsCovs))
 
-    obsCovs <- ddply(obsCovs, ~.site, function(df) {
-        site <- df$.site[1]
-        obs <- i[[site]]
-        if (length(obs) > R)
-            stop("All elements of list must be less than or equal to R.")
-        obs <- c(obs, rep(NA, R-length(obs)))
-        df[obs,]
-        })
-    obsCovs$.site <- NULL
+    oc <- lapply(1:m, function(ind){
+      df <- obsCovs[site_idx==ind,,drop=FALSE]
+      obs <- i[[ind]]
+      if (length(obs) > R)
+        stop("All elements of list must be less than or equal to R.")
+      obs <- c(obs, rep(NA, R-length(obs)))
+      df[obs,,drop=FALSE]
+    })
+    obsCovs <- do.call(rbind, oc)
+    rownames(obsCovs) <- NULL
 
     y <- apply(y, 1, function(row) {
         site <- row[1]

--- a/R/unmarkedFrame.R
+++ b/R/unmarkedFrame.R
@@ -1133,7 +1133,10 @@ setMethod("[", c("unmarkedFrame", "numeric", "missing", "missing"),
     if (!is.null(obsCovs)) {
         R <- obsNum(x)
         .site <- rep(1:M, each = R)
-        obsCovs <- obsCovs[.site%in%i,,drop=FALSE]
+        oc <- lapply(i, function(ind){
+         obsCovs[.site==ind,,drop=FALSE]
+        })
+        obsCovs <- do.call(rbind, oc)
         }
     umf <- x
     umf@y <- y
@@ -1233,7 +1236,10 @@ setMethod("[", c("unmarkedFrameOccuMulti", "numeric", "missing", "missing"),
     if (!is.null(obsCovs)) {
         R <- obsNum(x)
         .site <- rep(1:M, each = R)
-        obsCovs <- obsCovs[.site%in%i,,drop=FALSE]
+        oc <- lapply(i, function(ind){
+         obsCovs[.site==ind,,drop=FALSE]
+        })
+        obsCovs <- do.call(rbind, oc)
         }
     umf <- x
     umf@y <- ylist[[1]]
@@ -1306,7 +1312,10 @@ setMethod("[", c("unmarkedMultFrame", "numeric", "missing", "missing"),
     if (!is.null(obsCovs)) {
         R <- obsNum(x)
         .site <- rep(1:M, each = obsNum(x)) #NULL     ## testing
-        obsCovs <- obsCovs[.site%in%i,,drop=FALSE]
+        oc <- lapply(i, function(ind){
+         obsCovs[.site==ind,,drop=FALSE]
+        })
+        obsCovs <- do.call(rbind, oc)
         }
     u <- unmarkedMultFrame(y=matrix(y, ncol=ncol(oldy)),
                            siteCovs=siteCovs,


### PR DESCRIPTION
`plyr` functions are barely used. I replaced them with base R code so we can remove the dependency.